### PR TITLE
Add getter for the default foreground color in SquidPanel

### DIFF
--- a/src/main/java/squidpony/squidgrid/gui/SquidPanel.java
+++ b/src/main/java/squidpony/squidgrid/gui/SquidPanel.java
@@ -429,9 +429,26 @@ public class SquidPanel extends JLayeredPane {
         }
     }
 
-    public void setDefaultForeground(Color defaultForeground) {
-        this.defaultForeground = defaultForeground;
-    }
+	/**
+	 * Sets the default foreground color.
+	 * 
+	 * @param defaultForeground
+	 *            A non-{@code null} color.
+	 */
+	public void setDefaultForeground(Color defaultForeground) {
+		if (defaultForeground == null)
+			throw new NullPointerException("A null default foreground color is forbidden");
+		this.defaultForeground = defaultForeground;
+	}
+
+	/**
+	 * @return The default foreground color (if none was set with
+	 *         {@link #setDefaultForeground(Color)}), or the last color set with
+	 *         {@link #setDefaultForeground(Color)}. Cannot be {@code null}.
+	 */
+	public Color getDefaultForegroundColor() {
+		return defaultForeground;
+	}
 
     /**
      * Starts a bumping animation in the direction provided.


### PR DESCRIPTION
There's a setter for the default color, but no getter; which I need for a messages-area that is backed up by an instance of `SquidPanel`.