### PR TITLE
Introduce ISquidPanel that both the awt and gdx panels implement

### DIFF
--- a/squidlib-util/src/main/java/squidpony/panel/IColoredString.java
+++ b/squidlib-util/src/main/java/squidpony/panel/IColoredString.java
@@ -1,0 +1,260 @@
+package squidpony.panel;
+
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.ListIterator;
+
+import squidpony.annotation.Beta;
+
+/**
+ * A {@link String} divided in chunks of different colors. Use the
+ * {@link Iterable} interface to get the pieces.
+ * 
+ * @author smelC
+ * 
+ * @param <T>
+ *            The type of colors;
+ */
+@Beta
+public interface IColoredString<T> extends Iterable<IColoredString.Bucket<T>> {
+
+	/**
+	 * Mutates {@code this} by appending {@code c} to it.
+	 * 
+	 * @param c
+	 *            The text to append.
+	 * @param color
+	 *            {@code text}'s color. Or {@code null} to let the panel decide.
+	 */
+	public void append(char c, /* @Nullable */T color);
+
+	/**
+	 * Mutates {@code this} by appending {@code text} to it. Does nothing if
+	 * {@code text} is {@code null}.
+	 * 
+	 * @param text
+	 *            The text to append.
+	 * @param color
+	 *            {@code text}'s color. Or {@code null} to let the panel decide.
+	 */
+	public void append(/* @Nullable */String text, /* @Nullable */T color);
+
+	/**
+	 * Mutates {@code this} by appending {@code i} to it.
+	 * 
+	 * @param i
+	 *            The int to append.
+	 * @param color
+	 *            {@code text}'s color. Or {@code null} to let the panel decide.
+	 */
+	public void appendInt(int i, /* @Nullable */T color);
+
+	/**
+	 * Mutates {@code this} by appending {@code other} to it.
+	 * 
+	 * @param other
+	 */
+	public void append(IColoredString<T> other);
+
+	/**
+	 * Deletes all content after index {@code len} (if any).
+	 * 
+	 * @param len
+	 */
+	public void setLength(int len);
+
+	/**
+	 * @return The length of text.
+	 */
+	public int length();
+
+	/**
+	 * @return The text that {@code this} represents.
+	 */
+	public String present();
+
+	/**
+	 * A basic implementation of {@link IColoredString}.
+	 * 
+	 * @author smelC
+	 * 
+	 * @param <T>
+	 *            The type of colors
+	 */
+	public static class Impl<T> implements IColoredString<T> {
+
+		protected final LinkedList<Bucket<T>> fragments;
+
+		/**
+		 * An empty instance.
+		 */
+		public Impl() {
+			this.fragments = new LinkedList<Bucket<T>>();
+		}
+
+		@Override
+		public void append(char c, T color) {
+			append(String.valueOf(c), color);
+		}
+
+		@Override
+		public void append(String text, T color) {
+			if (text == null || text.isEmpty())
+				return;
+
+			if (fragments.isEmpty())
+				fragments.add(new Bucket<T>(text, color));
+			else {
+				final Bucket<T> last = fragments.getLast();
+				if (equals(last.color, color)) {
+					/* Append to the last bucket, to avoid extending the list */
+					final Bucket<T> novel = last.append(text);
+					fragments.removeLast();
+					fragments.addLast(novel);
+				} else
+					fragments.add(new Bucket<T>(text, color));
+			}
+		}
+
+		@Override
+		public void appendInt(int i, T color) {
+			append(String.valueOf(i), color);
+		}
+
+		@Override
+		/* KISS implementation */
+		public void append(IColoredString<T> other) {
+			for (IColoredString.Bucket<T> ofragment : other)
+				append(ofragment.getText(), ofragment.getColor());
+		}
+
+		@Override
+		public void setLength(int len) {
+			int l = 0;
+			final ListIterator<IColoredString.Bucket<T>> it = fragments.listIterator();
+			while (it.hasNext()) {
+				final IColoredString.Bucket<T> next = it.next();
+				final String ftext = next.text;
+				final int flen = ftext.length();
+				final int nextl = l + flen;
+				if (nextl < len)
+					/* Nothing to do */
+					continue;
+				else if (nextl == len) {
+					/* Delete all next fragments */
+					while (it.hasNext())
+						it.remove();
+					/* We'll exit the outer loop right away */
+				} else {
+					assert len < nextl;
+					/* Trim this fragment */
+					final IColoredString.Bucket<T> trimmed = next.setLength(nextl - l);
+					/* Replace this fragment */
+					it.remove();
+					it.add(trimmed);
+					/* Delete all next fragments */
+					while (it.hasNext())
+						it.remove();
+					/* We'll exit the outer loop right away */
+				}
+			}
+
+		}
+
+		@Override
+		public int length() {
+			int result = 0;
+			for (Bucket<T> fragment : fragments)
+				result += fragment.getText().length();
+			return result;
+		}
+
+		@Override
+		public String present() {
+			final StringBuilder result = new StringBuilder();
+			for (Bucket<T> fragment : fragments)
+				result.append(fragment.text);
+			return result.toString();
+		}
+
+		@Override
+		public Iterator<Bucket<T>> iterator() {
+			return fragments.iterator();
+		}
+
+		@Override
+		public String toString() {
+			return present();
+		}
+
+		protected static boolean equals(Object o1, Object o2) {
+			if (o1 == null)
+				return o2 == null;
+			else
+				return o1.equals(o2);
+		}
+	}
+
+	/**
+	 * A piece of a {@link IColoredString}: a text and its color.
+	 * 
+	 * @author smelC
+	 * 
+	 * @param <T>
+	 *            The type of colors;
+	 */
+	public static class Bucket<T> {
+
+		protected final String text;
+		protected final/* @Nullable */T color;
+
+		public Bucket(String text, /* @Nullable */T color) {
+			this.text = text == null ? "" : text;
+			this.color = color;
+		}
+
+		/**
+		 * @param text
+		 * @return An instance whose text is {@code this.text + text}. Color is
+		 *         unchanged.
+		 */
+		public Bucket<T> append(String text) {
+			if (text == null || text.isEmpty())
+				/* Let's save an allocation */
+				return this;
+			else
+				return new Bucket<T>(this.text + text, color);
+		}
+
+		public Bucket<T> setLength(int l) {
+			final int here = text.length();
+			if (here < l)
+				return this;
+			else
+				return new Bucket<T>(text.substring(0, l), color);
+		}
+
+		/**
+		 * @return The text that this bucket contains.
+		 */
+		public String getText() {
+			return text;
+		}
+
+		/**
+		 * @return The color of {@link #getText()}. Or {@code null} if none.
+		 */
+		public/* @Nullable */T getColor() {
+			return color;
+		}
+
+		@Override
+		public String toString() {
+			if (color == null)
+				return text;
+			else
+				return String.format("%s (%s)", text, color);
+		}
+
+	}
+}

--- a/squidlib-util/src/main/java/squidpony/panel/ICombinedPanel.java
+++ b/squidlib-util/src/main/java/squidpony/panel/ICombinedPanel.java
@@ -1,0 +1,203 @@
+package squidpony.panel;
+
+import java.util.LinkedList;
+import java.util.List;
+
+import squidpony.annotation.Beta;
+
+/**
+ * The combination of two panels, one to color the background, the other to
+ * write characters on the foreground.
+ * 
+ * @author smelC
+ * 
+ * @param <T>
+ *            The type of colors.
+ */
+@Beta
+public interface ICombinedPanel<T> {
+
+	/**
+	 * Puts the character {@code c} at {@code (x, y)}.
+	 * 
+	 * @param x
+	 * @param y
+	 * @param c
+	 */
+	public void putFG(int x, int y, char c);
+
+	/**
+	 * Puts the character {@code c} at {@code (x, y)} with some {@code color}.
+	 * 
+	 * @param x
+	 * @param y
+	 * @param c
+	 * @param color
+	 */
+	public void putFG(int x, int y, char c, T color);
+
+	/**
+	 * Puts the given string horizontally with the first character at the given
+	 * offset.
+	 *
+	 * Does not word wrap. Characters that are not renderable (due to being at
+	 * negative offsets or offsets greater than the grid size) will not be shown
+	 * but will not cause any malfunctions.
+	 *
+	 * @param x
+	 *            the x coordinate of the first character
+	 * @param y
+	 *            the y coordinate of the first character
+	 * @param string
+	 *            the characters to be displayed
+	 * @param color
+	 *            the color to draw the characters
+	 */
+	public void putFG(int x, int y, String string, T color);
+
+	/**
+	 * Puts the given string horizontally with the first character at the given
+	 * offset.
+	 *
+	 * Does not word wrap. Characters that are not renderable (due to being at
+	 * negative offsets or offsets greater than the grid size) will not be shown
+	 * but will not cause any malfunctions.
+	 *
+	 * @param x
+	 *            the x coordinate of the first character
+	 * @param y
+	 *            the y coordinate of the first character
+	 * @param cs
+	 *            the text to be displayed, with its color.
+	 */
+	public void putFG(int x, int y, IColoredString<? extends T> cs);
+
+	/**
+	 * Puts the color {@code c} at {@code (x, y)}.
+	 * 
+	 * @param x
+	 * @param y
+	 * @param color
+	 */
+	public void putBG(int x, int y, T color);
+
+	/**
+	 * @param margin
+	 *            The color to put at this panel's borders.
+	 * @param inside
+	 *            The color to put within this panel.
+	 */
+	public void fillBG(T margin, T inside);
+
+	public void refresh();
+
+	/**
+	 * @return The two backers, with the panel at the top (the foreground)
+	 *         first. They are instances of {@code SquidPanel}.
+	 */
+	public List<ISquidPanel<?>> getBackers();
+
+	/**
+	 * A basic implementation of {@link ICombinedPanel}.
+	 * 
+	 * @author smelC
+	 * 
+	 * @param <T>
+	 *            The type of colors.
+	 */
+	@Beta
+	public static class Impl<T> implements ICombinedPanel<T> {
+
+		protected final ISquidPanel<T> bg;
+		protected final ISquidPanel<T> fg;
+
+		protected final int width;
+		protected final int height;
+
+		/**
+		 * @param bg
+		 *            The backing background panel.
+		 * @param fg
+		 *            The backing foreground panel.
+		 * @param width
+		 *            The width of this panel, used for
+		 *            {@link #fillBG(Object, Object)} (so that it fills within
+		 *            {@code [0, width)}).
+		 * @param height
+		 *            The height of this panel, used for
+		 *            {@link #fillBG(Object, Object)} (so that it fills within
+		 *            {@code [0, height)}).
+		 * @throws IllegalStateException
+		 *             In various cases of errors regarding sizes of panels.
+		 */
+		public Impl(ISquidPanel<T> bg, ISquidPanel<T> fg, int width, int height) {
+			if (bg.gridWidth() != fg.gridWidth())
+				throw new IllegalStateException(
+						"Cannot build a combined panel with backers of different widths");
+			if (bg.gridHeight() != fg.gridHeight())
+				throw new IllegalStateException(
+						"Cannot build a combined panel with backers of different heights");
+
+			this.bg = bg;
+			this.fg = fg;
+			if (width < 0)
+				throw new IllegalStateException("Cannot create a panel with a negative width");
+			this.width = width;
+			if (height < 0)
+				throw new IllegalStateException("Cannot create a panel with a negative height");
+			this.height = height;
+		}
+
+		@Override
+		public void putFG(int x, int y, char c) {
+			fg.put(x, y, c);
+		}
+
+		@Override
+		public void putFG(int x, int y, char c, T color) {
+			fg.put(x, y, c, color);
+		}
+
+		@Override
+		public void putFG(int x, int y, String string, T foreground) {
+			fg.put(x, y, string, foreground);
+		}
+
+		@Override
+		public void putFG(int x, int y, IColoredString<? extends T> cs) {
+			fg.put(x, y, cs);
+		}
+
+		@Override
+		public void putBG(int x, int y, T color) {
+			bg.put(x, y, color);
+		}
+
+		@Override
+		public void fillBG(T margin, T inside) {
+			for (int x = 0; x < width; x++) {
+				for (int y = 0; y < height; y++) {
+					if (x == 0 || y == 0 || x == width - 1 || y == height - 1)
+						putBG(x, y, margin);
+					else
+						putBG(x, y, inside);
+				}
+			}
+		}
+
+		@Override
+		public void refresh() {
+			bg.refresh();
+			fg.refresh();
+		}
+
+		@Override
+		public List<ISquidPanel<?>> getBackers() {
+			final List<ISquidPanel<?>> backers = new LinkedList<ISquidPanel<?>>();
+			backers.add(fg.getBacker());
+			backers.add(bg.getBacker());
+			return backers;
+		}
+
+	}
+}

--- a/squidlib-util/src/main/java/squidpony/panel/ISquidPanel.java
+++ b/squidlib-util/src/main/java/squidpony/panel/ISquidPanel.java
@@ -1,0 +1,134 @@
+package squidpony.panel;
+
+import squidpony.annotation.Beta;
+
+/**
+ * The abstraction of {@code SquidPanel}s, to abstract from the UI
+ * implementation (i.e. whether it's awt or libgdx doesn't matter here).
+ * 
+ * @author smelC - Introduction of this interface, but methods were in
+ *         SquidPanel already.
+ * 
+ * @param <T>
+ *            The type of colors
+ * 
+ * @see ICombinedPanel The combination of two panels, one for the background,
+ *      one for the foreground; a frequent use case in roguelikes.
+ */
+@Beta
+public interface ISquidPanel<T> {
+
+	/**
+	 * Puts the character {@code c} at {@code (x, y)}.
+	 * 
+	 * @param x
+	 * @param y
+	 * @param c
+	 */
+	public void put(int x, int y, char c);
+
+	/**
+	 * Puts {@code color} at {@code (x, y)} (in the cell's entirety, i.e. in the
+	 * background).
+	 * 
+	 * @param x
+	 * @param y
+	 * @param color
+	 */
+	public void put(int x, int y, T color);
+
+	/**
+	 * Puts the given string horizontally with the first character at the given
+	 * offset.
+	 *
+	 * Does not word wrap. Characters that are not renderable (due to being at
+	 * negative offsets or offsets greater than the grid size) will not be shown
+	 * but will not cause any malfunctions.
+	 *
+	 * @param xOffset
+	 *            the x coordinate of the first character
+	 * @param yOffset
+	 *            the y coordinate of the first character
+	 * @param string
+	 *            the characters to be displayed
+	 * @param foreground
+	 *            the color to draw the characters
+	 */
+	public void put(int xOffset, int yOffset, String string, T foreground);
+
+	/**
+	 * Puts the given string horizontally with the first character at the given
+	 * offset, using the colors that {@code cs} provides.
+	 *
+	 * Does not word wrap. Characters that are not renderable (due to being at
+	 * negative offsets or offsets greater than the grid size) will not be shown
+	 * but will not cause any malfunctions.
+	 *
+	 * @param xOffset
+	 *            the x coordinate of the first character
+	 * @param yOffset
+	 *            the y coordinate of the first character
+	 * @param cs
+	 *            The string to display, with its colors.
+	 */
+	public void put(int xOffset, int yOffset, IColoredString<? extends T> cs);
+
+	/**
+	 * Puts the character {@code c} at {@code (x, y)} with some {@code color}.
+	 * 
+	 * @param x
+	 * @param y
+	 * @param c
+	 * @param color
+	 */
+	public void put(int x, int y, char c, T color);
+
+	public void put(char[][] foregrounds, T[][] colors);
+
+	/**
+	 * Removes the contents of this cell, leaving a transparent space.
+	 *
+	 * @param x
+	 * @param y
+	 */
+	public void clear(int x, int y);
+
+	/**
+	 * Cause everything that has been prepared for drawing (such as with put) to
+	 * actually be drawn.
+	 */
+	public void refresh();
+
+	public int gridWidth();
+
+	public int gridHeight();
+
+	/**
+	 * Sets the default foreground color.
+	 * 
+	 * @param color
+	 */
+	public void setDefaultForeground(T color);
+
+	/**
+	 * @return The default foreground color (if none was set with
+	 *         {@link #setDefaultForeground(Object)}), or the last color set
+	 *         with {@link #setDefaultForeground(Object)}. Cannot be
+	 *         {@code null}.
+	 */
+	public T getDefaultForegroundColor();
+
+	/**
+	 * @return The panel doing the real job, i.e. an instance of
+	 *         {@code SquidPanel}. The type of colors is unspecified, as some
+	 *         clients have forwarding instances of this class that hides that
+	 *         the type of color of the backer differs from the type of color in
+	 *         {@code this}.
+	 * 
+	 *         <p>
+	 *         Can be {@code this} itself.
+	 *         </p>
+	 */
+	public ISquidPanel<?> getBacker();
+
+}


### PR DESCRIPTION
* `ISquidPanel<T>` is merely the extraction of the methods of SquidPanel, except that the type of colors is generic (`T`). This'll help users that want to maximize their codebase that is shared between awt and android.
* I've added ICombinedPanel that shows how to lift ISquidPanel to have a panel that combines both a background and a foreground (a simpler SquidLayers).
* I've also added IColoredString to have an abstraction of string where differents parts have different colors, that is supported by ISquidPanel.
* I've left an interrogation in the gdx implementation of SquidPanel regarding ISquidPanel::refresh().