### PR TITLE
create javadoc for current target platform

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -150,6 +150,7 @@
 					<testWindowtitle>${project.name} ${project.version} (TEST API)</testWindowtitle>
 					<splitindex>true</splitindex>
 					<encoding>${project.build.sourceEncoding}</encoding>
+					<javadocVersion>${jdk.version}</javadocVersion>
 					<links>
 						<link>http://docs.oracle.com/javase/8/docs/api/</link>
 						<link>http://docs.oracle.com/javase/7/docs/api/</link>


### PR DESCRIPTION
related to #85:
doesn't suppress warnings but makes sure that javadoc will be created for the current target jre (which is 1.7)