### PR TITLE
Bust warnings (~100) in squidlib-util and squidlib-gdx: missing @Over…

### DIFF
--- a/squidlib-gdx/src/main/java/squidpony/squidgrid/gui/gdx/SColor.java
+++ b/squidlib-gdx/src/main/java/squidpony/squidgrid/gui/gdx/SColor.java
@@ -1,7 +1,6 @@
 package squidpony.squidgrid.gui.gdx;
 
 import com.badlogic.gdx.graphics.Color;
-import java.util.Objects;
 
 /**
  * Allows for the use of custom colors with custom names.

--- a/squidlib-gdx/src/main/java/squidpony/squidgrid/gui/gdx/SColorFactory.java
+++ b/squidlib-gdx/src/main/java/squidpony/squidgrid/gui/gdx/SColorFactory.java
@@ -8,6 +8,7 @@ import java.util.TreeMap;
 
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.math.MathUtils;
+
 import squidpony.squidmath.Bresenham;
 import squidpony.squidmath.Coord3D;
 import squidpony.squidmath.RNG;
@@ -95,7 +96,8 @@ public class SColorFactory {
      * @param coef
      * @return
      */
-    private static int blend(int a, int b, double coef) {
+    @SuppressWarnings("unused")
+	private static int blend(int a, int b, double coef) {
         coef = MathUtils.clamp(coef, 0, 1);
         return (int) (a + (b - a) * coef);
     }
@@ -569,15 +571,4 @@ public class SColorFactory {
         return color1.getName() + " to " + color2.getName();
     }
 
-    /**
-     * 
-     * @param color1
-     * @param color2
-     * @return
-     * 
-     * @deprecated Prefer paletteNamer to this misspelled version.
-     */
-    private static String palletNamer(SColor color1, SColor color2) {
-        return  paletteNamer(color1, color2);
-    }
 }

--- a/squidlib-gdx/src/main/java/squidpony/squidgrid/gui/gdx/SquidInput.java
+++ b/squidlib-gdx/src/main/java/squidpony/squidgrid/gui/gdx/SquidInput.java
@@ -262,7 +262,8 @@ public class SquidInput extends InputAdapter {
         queue.clear();
     }
 
-    public synchronized boolean keyDown (int keycode) {
+    @Override
+	public synchronized boolean keyDown (int keycode) {
         if(ignoreInput) return false;
         boolean alt = Gdx.input.isKeyPressed(Input.Keys.ALT_LEFT) || Gdx.input.isKeyPressed(Input.Keys.ALT_RIGHT),
                 ctrl = Gdx.input.isKeyPressed(Input.Keys.CONTROL_LEFT) || Gdx.input.isKeyPressed(Input.Keys.CONTROL_RIGHT),
@@ -280,41 +281,48 @@ public class SquidInput extends InputAdapter {
         return false;
     }
 
-    public synchronized boolean keyUp (int keycode) {
+    @Override
+	public synchronized boolean keyUp (int keycode) {
 //        queue.add(KEY_UP);
 //        queue.add(keycode);
         return false;
     }
 
-    public synchronized boolean keyTyped (char character) {
+    @Override
+	public synchronized boolean keyTyped (char character) {
         return false;
     }
 
-    public synchronized boolean touchDown (int screenX, int screenY, int pointer, int button) {
+    @Override
+	public synchronized boolean touchDown (int screenX, int screenY, int pointer, int button) {
         if(ignoreInput) return false;
         mouse.touchDown(screenX, screenY, pointer, button);
         return false;
     }
 
-    public synchronized boolean touchUp (int screenX, int screenY, int pointer, int button) {
+    @Override
+	public synchronized boolean touchUp (int screenX, int screenY, int pointer, int button) {
         if(ignoreInput) return false;
         mouse.touchUp(screenX, screenY, pointer, button);
         return false;
     }
 
-    public synchronized boolean touchDragged (int screenX, int screenY, int pointer) {
+    @Override
+	public synchronized boolean touchDragged (int screenX, int screenY, int pointer) {
         if(ignoreInput) return false;
         mouse.touchDragged(screenX, screenY, pointer);
         return false;
     }
 
-    public synchronized boolean mouseMoved (int screenX, int screenY) {
+    @Override
+	public synchronized boolean mouseMoved (int screenX, int screenY) {
         if(ignoreInput) return false;
         mouse.mouseMoved(screenX, screenY);
         return false;
     }
 
-    public synchronized boolean scrolled (int amount) {
+    @Override
+	public synchronized boolean scrolled (int amount) {
         if(ignoreInput) return false;
         mouse.scrolled(amount);
         return false;

--- a/squidlib-gdx/src/main/java/squidpony/squidgrid/gui/gdx/SquidKey.java
+++ b/squidlib-gdx/src/main/java/squidpony/squidgrid/gui/gdx/SquidKey.java
@@ -2,7 +2,6 @@ package squidpony.squidgrid.gui.gdx;
 
 import com.badlogic.gdx.InputProcessor;
 import com.badlogic.gdx.utils.IntArray;
-import com.badlogic.gdx.utils.TimeUtils;
 
 /**
  * This wraps an InputProcessor, storing all key events and allowing them to be processed one at a time using next() or
@@ -165,44 +164,52 @@ public class SquidKey implements InputProcessor {
         queue.clear();
     }
 
-    public synchronized boolean keyDown (int keycode) {
+    @Override
+	public synchronized boolean keyDown (int keycode) {
         if(ignoreInput) return false;
         queue.add(KEY_DOWN);
         queue.add(keycode);
         return false;
     }
 
-    public synchronized boolean keyUp (int keycode) {
+    @Override
+	public synchronized boolean keyUp (int keycode) {
         if(ignoreInput) return false;
         queue.add(KEY_UP);
         queue.add(keycode);
         return false;
     }
 
-    public synchronized boolean keyTyped (char character) {
+    @Override
+	public synchronized boolean keyTyped (char character) {
         if(ignoreInput) return false;
         queue.add(KEY_TYPED);
         queue.add(character);
         return false;
     }
 
-    public synchronized boolean touchDown (int screenX, int screenY, int pointer, int button) {
+    @Override
+	public synchronized boolean touchDown (int screenX, int screenY, int pointer, int button) {
         return false;
     }
 
-    public synchronized boolean touchUp (int screenX, int screenY, int pointer, int button) {
+    @Override
+	public synchronized boolean touchUp (int screenX, int screenY, int pointer, int button) {
         return false;
     }
 
-    public synchronized boolean touchDragged (int screenX, int screenY, int pointer) {
+    @Override
+	public synchronized boolean touchDragged (int screenX, int screenY, int pointer) {
         return false;
     }
 
-    public synchronized boolean mouseMoved (int screenX, int screenY) {
+    @Override
+	public synchronized boolean mouseMoved (int screenX, int screenY) {
         return false;
     }
 
-    public synchronized boolean scrolled (int amount) {
+    @Override
+	public synchronized boolean scrolled (int amount) {
         return false;
     }
 

--- a/squidlib-gdx/src/main/java/squidpony/squidgrid/gui/gdx/SquidPanel.java
+++ b/squidlib-gdx/src/main/java/squidpony/squidgrid/gui/gdx/SquidPanel.java
@@ -912,7 +912,6 @@ public class SquidPanel extends Group implements ISquidPanel<Color> {
      */
     public void wiggle(int x, int y, float duration) {
         final Actor a = cellToActor(x, y);
-        final int nextX = x, nextY = y;
         if(a == null) return;
         if(duration < 0.02f) duration = 0.02f;
         animationCount++;

--- a/squidlib-gdx/src/test/java/squidpony/gdx/examples/EverythingDemo.java
+++ b/squidlib-gdx/src/test/java/squidpony/gdx/examples/EverythingDemo.java
@@ -325,7 +325,7 @@ public class EverythingDemo extends ApplicationAdapter {
         fovmap = fov.calculateFOV(res, player.gridX, player.gridY, 8, Radius.SQUARE);
         // handle monster turns
         ArrayList<Coord> nextMovePositions = new ArrayList<>(25);
-        for(HashMap.Entry<AnimatedEntity, Integer> mon : monsters.entrySet())
+        for(Map.Entry<AnimatedEntity, Integer> mon : monsters.entrySet())
         {
             // monster values are used to store their aggression, 1 for actively stalking the player, 0 for not.
             if(mon.getValue() > 0 || fovmap[mon.getKey().gridX][mon.getKey().gridY] > 0.1)

--- a/squidlib-gdx/src/test/java/squidpony/gdx/examples/ImageDemo.java
+++ b/squidlib-gdx/src/test/java/squidpony/gdx/examples/ImageDemo.java
@@ -18,16 +18,13 @@ import squidpony.squidmath.RNG;
 import java.util.HashMap;
 
 public class ImageDemo extends ApplicationAdapter {
-    private enum Phase {WAIT, PLAYER_ANIM, MONSTER_ANIM}
     SpriteBatch batch;
 
-    private Phase phase = Phase.WAIT;
     private RNG rng;
     private LightRNG lrng;
     private SquidLayers display;
     private DungeonGenerator dungeonGen;
     private char[][] bareDungeon, lineDungeon;
-    private double[][] res;
     private int[][] colors, bgColors, lights;
     private int width, height;
     private int cellWidth, cellHeight;

--- a/squidlib-gdx/src/test/java/squidpony/gdx/examples/SquidAIDemo.java
+++ b/squidlib-gdx/src/test/java/squidpony/gdx/examples/SquidAIDemo.java
@@ -7,6 +7,7 @@ import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 import com.badlogic.gdx.scenes.scene2d.Stage;
 import com.badlogic.gdx.utils.viewport.ScreenViewport;
+
 import squidpony.squidai.*;
 import squidpony.squidgrid.LOS;
 import squidpony.squidgrid.Radius;
@@ -203,8 +204,7 @@ public class SquidAIDemo extends ApplicationAdapter {
         int i = 0;
         DijkstraMap whichDijkstra;
         Technique whichTech;
-        Set<Coord> whichFoes, whichAllies, visibleTargets = new LinkedHashSet<>(8);
-        LinkedHashMap<AnimatedEntity, Integer> whichEnemyTeam = null;
+        Set<Coord> whichFoes, whichAllies = new LinkedHashSet<>(8);
         AnimatedEntity ae = null;
         int health = 0;
         Coord user = null;
@@ -214,7 +214,6 @@ public class SquidAIDemo extends ApplicationAdapter {
             whichTech = (idx % 2 == 0) ? blueBeam : blueBlast;
             whichFoes = redPlaces;
             whichAllies = bluePlaces;
-            whichEnemyTeam = teamRed;
             for(Map.Entry<AnimatedEntity, Integer> entry : teamBlue.entrySet())
             {
                 if(i++ == idx)
@@ -232,7 +231,6 @@ public class SquidAIDemo extends ApplicationAdapter {
             whichTech = (idx % 2 == 0) ? redCloud : redCone;
             whichFoes = bluePlaces;
             whichAllies = redPlaces;
-            whichEnemyTeam = teamBlue;
             for(Map.Entry<AnimatedEntity, Integer> entry : teamRed.entrySet())
             {
                 if(i++ == idx)
@@ -282,7 +280,8 @@ public class SquidAIDemo extends ApplicationAdapter {
     }
 
     // check if a monster's movement would overlap with another monster.
-    private boolean checkOverlap(AnimatedEntity ae, int x, int y)
+    @SuppressWarnings("unused")
+	private boolean checkOverlap(AnimatedEntity ae, int x, int y)
     {
         for(AnimatedEntity mon : teamRed.keySet())
         {
@@ -300,7 +299,6 @@ public class SquidAIDemo extends ApplicationAdapter {
     private void postMove(int idx) {
 
         int i = 0;
-        DijkstraMap whichDijkstra;
         Technique whichTech;
         Set<Coord> whichFoes, whichAllies, visibleTargets = new LinkedHashSet<>(8);
         AnimatedEntity ae = null;
@@ -310,7 +308,6 @@ public class SquidAIDemo extends ApplicationAdapter {
         LinkedHashMap<AnimatedEntity, Integer> whichEnemyTeam = null;
         LinkedHashMap<Coord, Double> effects = null;
         if (blueTurn) {
-            whichDijkstra = getToRed;
             whichTech = (idx % 2 == 0) ? blueBeam : blueBlast;
             whichFoes = redPlaces;
             whichAllies = bluePlaces;
@@ -325,7 +322,6 @@ public class SquidAIDemo extends ApplicationAdapter {
                 }
             }
         } else {
-            whichDijkstra = getToBlue;
             whichTech = (idx % 2 == 0) ? redCloud : redCone;
             whichFoes = bluePlaces;
             whichAllies = redPlaces;
@@ -456,15 +452,11 @@ public class SquidAIDemo extends ApplicationAdapter {
         }
         int i = 0;
         AnimatedEntity ae = null;
-        int health = 0;
-        Coord user = null;
         int whichIdx = 0;
         if(blueTurn) {
             for (Map.Entry<AnimatedEntity, Integer> entry : teamBlue.entrySet()) {
                 if (i++ == blueIdx) {
                     ae = entry.getKey();
-                    health = entry.getValue();
-                    user = Coord.get(ae.gridX, ae.gridY);
                     whichIdx = blueIdx;
                     break;
                 }
@@ -475,8 +467,6 @@ public class SquidAIDemo extends ApplicationAdapter {
             for (Map.Entry<AnimatedEntity, Integer> entry : teamRed.entrySet()) {
                 if (i++ == redIdx) {
                     ae = entry.getKey();
-                    health = entry.getValue();
-                    user = Coord.get(ae.gridX, ae.gridY);
                     whichIdx = redIdx;
                     break;
                 }

--- a/squidlib-util/src/main/java/squidpony/squidai/BeamAOE.java
+++ b/squidlib-util/src/main/java/squidpony/squidai/BeamAOE.java
@@ -157,11 +157,13 @@ public class BeamAOE implements AOE {
         return dijkstra.partialScan(radius, null);
     }
 
-    public Coord getOrigin() {
+    @Override
+	public Coord getOrigin() {
         return origin;
     }
 
-    public void setOrigin(Coord origin) {
+    @Override
+	public void setOrigin(Coord origin) {
         this.origin = origin;
         dijkstra.resetMap();
         dijkstra.clearGoals();

--- a/squidlib-util/src/main/java/squidpony/squidai/BlastAOE.java
+++ b/squidlib-util/src/main/java/squidpony/squidai/BlastAOE.java
@@ -42,13 +42,6 @@ public class BlastAOE implements AOE {
         this.minRange = minRange;
         this.maxRange = maxRange;
     }
-    private BlastAOE()
-    {
-        fov = new FOV(FOV.RIPPLE_LOOSE);
-        center = Coord.get(1, 1);
-        radius = 1;
-        radiusType = Radius.DIAMOND;
-    }
 
     public Coord getCenter() {
         return center;

--- a/squidlib-util/src/main/java/squidpony/squidai/BurstAOE.java
+++ b/squidlib-util/src/main/java/squidpony/squidai/BurstAOE.java
@@ -42,13 +42,6 @@ public class BurstAOE implements AOE {
         this.minRange = minRange;
         this.maxRange = maxRange;
     }
-    private BurstAOE()
-    {
-        fov = new FOV(FOV.SHADOW);
-        center = Coord.get(1, 1);
-        radius = 1;
-        radiusType = Radius.DIAMOND;
-    }
 
     public Coord getCenter() {
         return center;

--- a/squidlib-util/src/main/java/squidpony/squidai/CloudAOE.java
+++ b/squidlib-util/src/main/java/squidpony/squidai/CloudAOE.java
@@ -121,17 +121,6 @@ public class CloudAOE implements AOE {
         this.minRange = minRange;
         this.maxRange = maxRange;
     }
-    private CloudAOE()
-    {
-        LightRNG l = new LightRNG();
-        this.seed = l.getState();
-        this.spill = new Spill(new RNG(l));
-        this.center = Coord.get(1, 1);
-        this.volume = 1;
-        this.spill.measurement = Spill.Measurement.MANHATTAN;
-        rt = Radius.DIAMOND;
-        this.expanding = false;
-    }
 
     public Coord getCenter() {
         return center;

--- a/squidlib-util/src/main/java/squidpony/squidai/ConeAOE.java
+++ b/squidlib-util/src/main/java/squidpony/squidai/ConeAOE.java
@@ -30,7 +30,6 @@ public class ConeAOE implements AOE {
     private int minRange = 1, maxRange = 1;
     private Radius metric = Radius.SQUARE;
 
-    private final static double PI2 = Math.PI * 2;
     public ConeAOE(Coord origin, Coord endCenter, double span, Radius radiusType)
     {
         fov = new FOV(FOV.RIPPLE_LOOSE);
@@ -54,23 +53,13 @@ public class ConeAOE implements AOE {
         this.radiusType = radiusType;
     }
 
-    private ConeAOE()
-    {
-        fov = new FOV(FOV.RIPPLE_LOOSE);
-        this.origin = Coord.get(1, 1);
-        this.radius = 1;
-//        this.startAngle = 0;
-//        this.endAngle = 90;
-        this.angle = 45;
-        this.span = 90;
-        this.radiusType = Radius.DIAMOND;
-    }
-
-    public Coord getOrigin() {
+    @Override
+	public Coord getOrigin() {
         return origin;
     }
 
-    public void setOrigin(Coord origin) {
+    @Override
+	public void setOrigin(Coord origin) {
         this.origin = origin;
     }
 
@@ -244,7 +233,6 @@ public class ConeAOE implements AOE {
             tmpfov = fov.calculateFOV(map, origin.x, origin.y, radius, radiusType, tAngle, span);
 
 
-            double dist = 0.0;
             for (int x = 0; x < dungeon.length; x++) {
                 for (int y = 0; y < dungeon[x].length; y++) {
                     if (tmpfov[x][y] > 0.0)
@@ -375,7 +363,6 @@ public class ConeAOE implements AOE {
             tmpfov = fov.calculateFOV(map, origin.x, origin.y, radius, radiusType, tAngle, span);
 
 
-            double dist = 0.0;
             for (int x = 0; x < dungeon.length; x++) {
                 for (int y = 0; y < dungeon[x].length; y++) {
                     if (tmpfov[x][y] > 0.0){
@@ -415,7 +402,6 @@ public class ConeAOE implements AOE {
 //            tEndAngle = Math.abs((tAngle + span / 2.0) % 360.0);
             tmpfov = fov.calculateFOV(map, origin.x, origin.y, radius, radiusType, tAngle, span);
 
-            double dist = 0.0;
             for (int x = 0; x < dungeon.length; x++) {
                 for (int y = 0; y < dungeon[x].length; y++) {
                     if (tmpfov[x][y] > 0.0){

--- a/squidlib-util/src/main/java/squidpony/squidai/PointAOE.java
+++ b/squidlib-util/src/main/java/squidpony/squidai/PointAOE.java
@@ -20,7 +20,6 @@ import java.util.Set;
 public class PointAOE implements AOE {
     private Coord center, origin = null;
     private Radius limitType = null;
-    private char[][] dungeon;
     private int minRange = 1, maxRange = 1;
     private Radius metric = Radius.SQUARE;
     public PointAOE(Coord center)
@@ -32,11 +31,6 @@ public class PointAOE implements AOE {
         this.center = center;
         this.minRange = minRange;
         this.maxRange = maxRange;
-    }
-
-    private PointAOE()
-    {
-        center = Coord.get(1, 1);
     }
 
     public Coord getCenter() {
@@ -216,7 +210,10 @@ public class PointAOE implements AOE {
 */
     @Override
     public void setMap(char[][] map) {
-        this.dungeon = map;
+		/*
+		 * Nothing do do. smelc's note: previously 'map' was assigned in a field
+		 * that was never redd.
+		 */
     }
 
     @Override

--- a/squidlib-util/src/main/java/squidpony/squidai/Technique.java
+++ b/squidlib-util/src/main/java/squidpony/squidai/Technique.java
@@ -1,6 +1,5 @@
 package squidpony.squidai;
 
-import squidpony.squidgrid.Radius;
 import squidpony.squidmath.Coord;
 
 import java.util.ArrayList;

--- a/squidlib-util/src/main/java/squidpony/squidgrid/SoundMap.java
+++ b/squidlib-util/src/main/java/squidpony/squidgrid/SoundMap.java
@@ -79,7 +79,6 @@ public class SoundMap
      * The RNG used to decide which one of multiple equally-short paths to take.
      */
     public RNG rng;
-    private int frustration = 0;
 
     private boolean initialized = false;
     /**
@@ -267,7 +266,6 @@ public class SoundMap
         alerted.clear();
         fresh.clear();
         sounds.clear();
-        frustration = 0;
     }
 
     /**

--- a/squidlib-util/src/main/java/squidpony/squidgrid/Spill.java
+++ b/squidlib-util/src/main/java/squidpony/squidgrid/Spill.java
@@ -83,7 +83,6 @@ public class Spill {
      * The LightRNG used as a RandomnessSource for the RNG this object uses. Can have its state read and set.
      */
     public LightRNG lrng;
-    private int frustration = 0;
 
     private boolean initialized = false;
     /**
@@ -323,7 +322,6 @@ public class Spill {
         resetMap();
         spreadPattern.clear();
         fresh.clear();
-        frustration = 0;
     }
 
     /**

--- a/squidlib-util/src/main/java/squidpony/squidgrid/iterator/SquidIterators.java
+++ b/squidlib-util/src/main/java/squidpony/squidgrid/iterator/SquidIterators.java
@@ -109,6 +109,11 @@ public class SquidIterators {
 			}
 		}
 
+		@Override
+		public void remove() {
+			throw new UnsupportedOperationException();
+		}
+
 		protected boolean gridIsEmpty() {
 			return width == 0 || height == 0;
 		}
@@ -244,6 +249,11 @@ public class SquidIterators {
 			return next;
 		}
 
+		@Override
+		public void remove() {
+			throw new UnsupportedOperationException();
+		}
+
 	}
 
 	/* **************************************************************************************************** */
@@ -316,6 +326,11 @@ public class SquidIterators {
 			if (result == null)
 				throw new NoSuchElementException();
 			return result;
+		}
+
+		@Override
+		public void remove() {
+			throw new UnsupportedOperationException();
 		}
 
 		/*
@@ -432,6 +447,11 @@ public class SquidIterators {
 			if (prev == null)
 				throw new NoSuchElementException();
 			return prev;
+		}
+
+		@Override
+		public void remove() {
+			throw new UnsupportedOperationException();
 		}
 
 		protected Coord findNext() {

--- a/squidlib-util/src/main/java/squidpony/squidgrid/mapping/ClassicRogueMapGenerator.java
+++ b/squidlib-util/src/main/java/squidpony/squidgrid/mapping/ClassicRogueMapGenerator.java
@@ -2,10 +2,10 @@ package squidpony.squidgrid.mapping;
 
 
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.Deque;
 import java.util.LinkedList;
 import java.util.List;
+
 import squidpony.squidgrid.Direction;
 import squidpony.squidmath.Coord;
 import squidpony.squidmath.RNG;
@@ -367,6 +367,13 @@ public class ClassicRogueMapGenerator {
                 map[x][y] = Terrain.CLOSED_DOOR;
                 p = Coord.get(x, y + 1);
                 break;
+        case NONE:
+        	break;
+		case DOWN_LEFT:
+		case DOWN_RIGHT:
+		case UP_LEFT:
+		case UP_RIGHT:
+			throw new IllegalStateException("There should only be cardinal positions here");
         }
 
         return p;

--- a/squidlib-util/src/main/java/squidpony/squidgrid/mapping/DividedMazeGenerator.java
+++ b/squidlib-util/src/main/java/squidpony/squidgrid/mapping/DividedMazeGenerator.java
@@ -116,6 +116,13 @@ public class DividedMazeGenerator {
                             map[x2][y] = true;
                         }
                         break;
+                    case NONE:
+                    	break;
+				case DOWN_LEFT:
+				case DOWN_RIGHT:
+				case UP_LEFT:
+				case UP_RIGHT:
+					throw new IllegalStateException("There should only be cardinal directions here");
                 }
             }
 
@@ -136,6 +143,13 @@ public class DividedMazeGenerator {
                     case DOWN:
                         map[x2][rng.between(y2 + 1, room.bottom + 1)] = false;
                         break;
+                    case NONE:
+                    	break;
+				case DOWN_LEFT:
+				case DOWN_RIGHT:
+				case UP_LEFT:
+				case UP_RIGHT:
+					throw new IllegalStateException("There should only be cardinal directions here");
                 }
             }
 

--- a/squidlib-util/src/main/java/squidpony/squidgrid/mapping/DungeonGenerator.java
+++ b/squidlib-util/src/main/java/squidpony/squidgrid/mapping/DungeonGenerator.java
@@ -521,7 +521,8 @@ public class DungeonGenerator {
      *
      * @return
      */
-    public String toString() {
+    @Override
+	public String toString() {
         char[][] trans = new char[height][width];
         for (int x = 0; x < width; x++) {
             for (int y = 0; y < height; y++) {

--- a/squidlib-util/src/main/java/squidpony/squidgrid/mapping/GrowingTreeMazeGenerator.java
+++ b/squidlib-util/src/main/java/squidpony/squidgrid/mapping/GrowingTreeMazeGenerator.java
@@ -2,9 +2,7 @@ package squidpony.squidgrid.mapping;
 
 
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
+
 import squidpony.annotation.Beta;
 import squidpony.squidgrid.Direction;
 import squidpony.squidmath.Coord;

--- a/squidlib-util/src/main/java/squidpony/squidgrid/mapping/MetsaMapFactory.java
+++ b/squidlib-util/src/main/java/squidpony/squidgrid/mapping/MetsaMapFactory.java
@@ -2,12 +2,12 @@ package squidpony.squidgrid.mapping;
 
 import java.util.LinkedList;
 import java.util.List;
+
 import squidpony.annotation.Beta;
 import squidpony.squidmath.Coord;
 import squidpony.squidmath.PerlinNoise;
 import squidpony.squidmath.RNG;
 import squidpony.squidmath.StatefulRNG;
-
 import static java.lang.Math.round;
 
 /**
@@ -36,26 +36,21 @@ public class MetsaMapFactory {
      5 = snowcap
      6 = lowsea
      */
-    static private final int[] colors = new int[]{0x1560BD, 0xD2B48C, 0x7BA05B,
-        0x228B22, 0x708090, 0xf0f8ff, 0x007FFF};
-    static private final int[] polarcolors = colors;
 //            new SColor[]{SColor.DARK_SLATE_GRAY, SColor.SCHOOL_BUS_YELLOW, SColor.YELLOW_GREEN,
 //        SColor.GREEN_BAMBOO, SColorFactory.lighter(SColor.LIGHT_BLUE_SILK), SColor.ALICE_BLUE, SColor.AZUL};
-    static private final int[] desertcolors = colors;
 //            new SColor[]{SColor.DARK_SLATE_GRAY, SColor.SCHOOL_BUS_YELLOW, SColor.YELLOW_GREEN,
 //        SColor.GREEN_BAMBOO, SColorFactory.lighter(SColor.LIGHT_BLUE_SILK), SColor.ALICE_BLUE, SColor.AZUL};
 
     static private final int width = 1500;
     static private final int height = 1000;
-    static private final int scale = 1;
-    static private final int ROADS = 64;
     static private final int CITYAMOUNT = 14;
 
     private List<Coord> cities = new LinkedList<>();
     private final RNG rng = new RNG();
     private double highn = 0;
 
-    private int getShadow(int x, int y, double[][] map) {
+    @SuppressWarnings("unused")
+	private int getShadow(int x, int y, double[][] map) {
         if (x >= width - 1 || y <= 0) {
             return 0;
         }
@@ -89,7 +84,8 @@ public class MetsaMapFactory {
      * @param point
      * @return
      */
-    private Coord closestCity(Coord point) {
+    @SuppressWarnings("unused")
+	private Coord closestCity(Coord point) {
         double dist = 999999999, newdist;
         Coord closest = null;
         for (Coord c : cities) {
@@ -105,7 +101,8 @@ public class MetsaMapFactory {
         return closest;
     }
 
-    private double[][] makeHeightMap() {
+    @SuppressWarnings("unused")
+	private double[][] makeHeightMap() {
         double[][] map = MapFactory.heightMap(width, height, new StatefulRNG());
 
         for (int x = 0; x < width; x++) {
@@ -120,7 +117,8 @@ public class MetsaMapFactory {
         return map;
     }
 
-    private int[][] makeBiomeMap(double[][] map) {
+    @SuppressWarnings("unused")
+	private int[][] makeBiomeMap(double[][] map) {
         //biomes 0 normal 1 snow
         int biomeMap[][] = new int[width][height];
         for (int x = 0; x < width; x++) {
@@ -142,7 +140,8 @@ public class MetsaMapFactory {
         return biomeMap;
     }
 
-    private int[][] makeNationMap(double[][] map) {
+    @SuppressWarnings("unused")
+	private int[][] makeNationMap(double[][] map) {
         // nationmap, 4 times less accurate map used for nations -1 no nation
         int nationMap[][] = new int[width][height];
         for (int i = 0; i < width / 4; i++) {
@@ -157,7 +156,8 @@ public class MetsaMapFactory {
         return nationMap;
     }
 
-    private double[][] makeWeightedMap(double[][] map) {
+    @SuppressWarnings("unused")
+	private double[][] makeWeightedMap(double[][] map) {
         //Weighted map for road
         double weightedMap[][] = new double[width][height];
         double SEALEVEL = 0;
@@ -185,33 +185,6 @@ public class MetsaMapFactory {
             cities.add(Coord.get(4 * round(px / 4), 4 * round(py / 4)));
         }
         return weightedMap;
-    }
-
-    private void generateRoads() {
-        ////Generate a road
-//Queue results
-//if (ROADS > 0) {
-//            var graph = new Graph(weighedMap, {
-//                diagonal
-//        
-//            : true
-//    });
-//    console.log(cities.length);
-//            for (ii = 0; ii < cities.length; ii++) {
-//                var startc = cities[ii];
-//                console.log(start);
-//                var start = graph.grid[startc.x / 4][startc.y / 4];
-//                var endc = closestCity(cities[ii]);
-//                console.log(end);
-//                var end = graph.grid[endc.x / 4][endc.y / 4];
-//
-//                var res = astar.search(graph, start, end);
-//                if (res.length != 0) {
-//                    results.push(res);
-//                }
-//            }
-//
-//        }
     }
 
 }

--- a/squidlib-util/src/main/java/squidpony/squidgrid/mapping/styled/DungeonBoneGen.java
+++ b/squidlib-util/src/main/java/squidpony/squidgrid/mapping/styled/DungeonBoneGen.java
@@ -542,7 +542,8 @@ public class DungeonBoneGen {
      *
      * @return
      */
-    public String toString() {
+    @Override
+	public String toString() {
         char[][] trans = new char[high][wide];
         for (int x = 0; x < wide; x++) {
             for (int y = 0; y < high; y++) {

--- a/squidlib-util/src/main/java/squidpony/squidmath/Coord3D.java
+++ b/squidlib-util/src/main/java/squidpony/squidmath/Coord3D.java
@@ -8,7 +8,9 @@ package squidpony.squidmath;
  */
 public class Coord3D extends Coord {
 
-    public int z;
+	public int z;
+
+	private static final long serialVersionUID = 1835370798982845336L;
 
     /**
      * Creates a three dimensional coordinate with the given location.

--- a/squidlib-util/src/main/java/squidpony/squidmath/CoordDouble.java
+++ b/squidlib-util/src/main/java/squidpony/squidmath/CoordDouble.java
@@ -1,7 +1,5 @@
 package squidpony.squidmath;
 
-import java.util.DoubleSummaryStatistics;
-
 /**
  * Coord using double values for x and y instead of int. Not pooled.
  * Created by Tommy Ettinger on 8/12/2015.
@@ -92,7 +90,8 @@ public class CoordDouble implements java.io.Serializable {
         this.y = y;
     }
 
-    public String toString()
+    @Override
+	public String toString()
     {
         return "Coord (x " + x + ", y " + y + ")";
     }

--- a/squidlib-util/src/main/java/squidpony/squidmath/DharmaRNG.java
+++ b/squidlib-util/src/main/java/squidpony/squidmath/DharmaRNG.java
@@ -294,7 +294,8 @@ public class DharmaRNG extends RNG {
      * @param bound the upper bound (exclusive)
      * @return the found number
      */
-    public long nextLong(long bound) {
+    @Override
+	public long nextLong(long bound) {
         if (bound <= 0) {
             return 0;
         }

--- a/squidlib-util/src/main/java/squidpony/squidmath/Dice.java
+++ b/squidlib-util/src/main/java/squidpony/squidmath/Dice.java
@@ -49,7 +49,6 @@ public class Dice {
     public int bestOf(int n, int dice, int sides) {
         int rolls = Math.min(n, dice);
         ArrayList<Integer> results = new ArrayList<>(dice);
-        int ret = 0;
 
         for (int i = 0; i < dice; i++) {
             results.add(rollDice(1, sides));

--- a/squidlib-util/src/main/java/squidpony/squidmath/Elias.java
+++ b/squidlib-util/src/main/java/squidpony/squidmath/Elias.java
@@ -116,8 +116,8 @@ public class Elias {
 
     private void runLine(double startx, double starty, double endx, double endy) {
         double x1 = startx, y1 = starty, x2 = endx, y2 = endy;
-        double grad, xd, yd, length, xm, ym, xgap, ygap, xend, yend, xf, yf, brightness1, brightness2;
-        int x, y, ix1, ix2, iy1, iy2;
+        double grad, xd, yd, xgap, xend, yend, yf, brightness1, brightness2;
+        int x, ix1, ix2, iy1, iy2;
         boolean shallow = false;
 
         xd = x2 - x1;

--- a/squidlib-util/src/main/java/squidpony/squidmath/LightRNG.java
+++ b/squidlib-util/src/main/java/squidpony/squidmath/LightRNG.java
@@ -18,7 +18,6 @@ package squidpony.squidmath;
  */
 public class LightRNG implements RandomnessSource, StatefulRandomness
 {
-    private static final long serialVersionUID = 4L;
     /** 2 raised to the 53, - 1. */
     private static final long DOUBLE_MASK = ( 1L << 53 ) - 1;
     /** 2 raised to the -53. */
@@ -161,13 +160,15 @@ public class LightRNG implements RandomnessSource, StatefulRandomness
     /**
      * Sets the seed (also the current state) of this generator.
      */
-    public void setState( final long seed ) {
+    @Override
+	public void setState( final long seed ) {
         state = seed;
     }
     /**
      * Gets the current state of this generator.
      */
-    public long getState( ) {
+    @Override
+	public long getState( ) {
         return state;
     }
 

--- a/squidlib-util/src/main/java/squidpony/squidmath/PermutedRNG.java
+++ b/squidlib-util/src/main/java/squidpony/squidmath/PermutedRNG.java
@@ -21,7 +21,6 @@ package squidpony.squidmath;
  */
 public class PermutedRNG implements RandomnessSource, StatefulRandomness
 {
-    private static final long serialVersionUID = 4L;
     /** 2 raised to the 53, - 1. */
     private static final long DOUBLE_MASK = ( 1L << 53 ) - 1;
     /** 2 raised to the -53. */
@@ -187,13 +186,15 @@ public class PermutedRNG implements RandomnessSource, StatefulRandomness
     /**
      * Sets the seed (also the current state) of this generator.
      */
-    public void setState( final long seed ) {
+    @Override
+	public void setState( final long seed ) {
         state = seed;
     }
     /**
      * Gets the current state of this generator.
      */
-    public long getState( ) {
+    @Override
+	public long getState( ) {
         return state;
     }
 

--- a/squidlib-util/src/main/java/squidpony/squidmath/RNG.java
+++ b/squidlib-util/src/main/java/squidpony/squidmath/RNG.java
@@ -51,7 +51,7 @@ public class RNG {
         if (ran == null) {
             ran = new Random() {
                 @Override
-                protected int next(int bits) {
+				protected int next(int bits) {
                     return super.next(bits);
                 }
             };
@@ -253,6 +253,11 @@ public class RNG {
                     }
 
                     @Override
+					public void remove() {
+                    	throw new UnsupportedOperationException();
+					}
+
+					@Override
                     public String toString() {
                         return "RandomStartIterator at index " + next;
                     }

--- a/squidlib-util/src/main/java/squidpony/squidmath/XorRNG.java
+++ b/squidlib-util/src/main/java/squidpony/squidmath/XorRNG.java
@@ -17,8 +17,6 @@ package squidpony.squidmath;
  */
 public class XorRNG implements RandomnessSource {
 
-    private static final long serialVersionUID = 3L;
-
     private static final long DOUBLE_MASK = (1L << 53) - 1;
     private static final double NORM_53 = 1. / (1L << 53);
     private static final long FLOAT_MASK = (1L << 24) - 1;

--- a/squidlib/src/main/java/squidpony/squidgrid/gui/SColorFactory.java
+++ b/squidlib/src/main/java/squidpony/squidgrid/gui/SColorFactory.java
@@ -27,11 +27,11 @@ import squidpony.squidmath.RNG;
  */
 public class SColorFactory {
 
-    private static final TreeMap<String, SColor> nameLookup = new TreeMap<>();
-    private static final TreeMap<Integer, SColor> valueLookup = new TreeMap<>();
+    private static final TreeMap<String, SColor> nameLookup = new TreeMap<String, SColor>();
+    private static final TreeMap<Integer, SColor> valueLookup = new TreeMap<Integer, SColor>();
     private static RNG rng = new RNG();
-    private static Map<Integer, SColor> colorBag = new HashMap<>();
-    private static Map<String, ArrayList<SColor>> palettes = new HashMap<>();
+    private static Map<Integer, SColor> colorBag = new HashMap<Integer, SColor>();
+    private static Map<String, ArrayList<SColor>> palettes = new HashMap<String, ArrayList<SColor>>();
     private static int floor = 1;//what multiple to floor rgb values to in order to reduce total colors
 
     /**
@@ -167,7 +167,7 @@ public class SColorFactory {
      * areas that will not be revisited.
      */
     public static void emptyCache() {
-        colorBag = new HashMap<>();
+        colorBag = new HashMap<Integer, SColor>();
     }
 
     /**
@@ -383,7 +383,7 @@ public class SColorFactory {
 
         //get the gradient
         Queue<Coord3D> gradient = Bresenham.line3D(scolorToCoord3D(color1), scolorToCoord3D(color2));
-        ArrayList<SColor> ret = new ArrayList<>();
+        ArrayList<SColor> ret = new ArrayList<SColor>();
         for (Coord3D coord : gradient) {
             ret.add(coord3DToSColor(coord));
         }
@@ -496,7 +496,7 @@ public class SColorFactory {
      * @param palette
      */
     public static void addPalette(String name, ArrayList<SColor> palette) {
-        ArrayList<SColor> temp = new ArrayList<>();
+        ArrayList<SColor> temp = new ArrayList<SColor>();
 
         //make sure all the colors in the palette are also in the general color cache
         for (SColor sc : palette) {
@@ -514,7 +514,7 @@ public class SColorFactory {
      * @deprecated Prefer addPalette
      */
     public static void addPallet(String name, ArrayList<SColor> palette) {
-        ArrayList<SColor> temp = new ArrayList<>();
+        ArrayList<SColor> temp = new ArrayList<SColor>();
 
         //make sure all the colors in the palette are also in the general color cache
         for (SColor sc : palette) {


### PR DESCRIPTION
…ride, dead fields and methods, and missing/useless serialversionIDs.

The changes were mostly trivial except that I added some missing cases in switchs (diagonals in code that only expected cardinal directions, because leaving unspecified cases without `default` is dangerous). I now have only three remaining warnings (javadoc being omitted) in squidlib-util and squidlib-gdx:

* Resource leak: '<unassigned Closeable value>' in DungeonBoneGen.java. I think that closing the java `Scanner` is wrong, because it would close the `InputStream` received as parameter. Hence I believe that this warning should receive a SuppressWarning, but I left it to the person that wrote this (tricky) code.
* A useless import in DijkstraMap.java, because I didn't want to step on @tommyettinger's toes.
* I left a missing serialVersionUID field in SColorChooserPanel.java. I do not understand the point of the anonymous `Random` class that is created here, whose only method calls its super class (hence what's the relation with `this` ?).