### PR TITLE
Make SquidPanel depend on IColorCenter, by pushing @tommyettinger get…

### DIFF
--- a/squidlib-util/src/main/java/squidpony/IColorCenter.java
+++ b/squidlib-util/src/main/java/squidpony/IColorCenter.java
@@ -170,6 +170,12 @@ public interface IColorCenter<T> {
      */
     float getValue(T c);
 
+    /**
+     * @param c
+     * @return The color that {@code this} shows when {@code c} is requested. May be {@code c} itself.
+     */
+    T filter(T c);
+
 	/**
 	 * A skeletal implementation of {@link IColorCenter}.
 	 * 
@@ -405,6 +411,12 @@ public interface IColorCenter<T> {
         @Override
         public float getHue(T c) {
             return getHue(getRed(c) / 255f, getGreen(c) / 255f, getBlue(c) / 255f);
+        }
+
+        @Override
+		public T filter(T c)
+        {
+        	return get(getRed(c), getGreen(c), getBlue(c), getAlpha(c));
         }
 
         /**

--- a/squidlib/src/main/java/squidpony/squidgrid/gui/gdx/SquidColorCenter.java
+++ b/squidlib/src/main/java/squidpony/squidgrid/gui/gdx/SquidColorCenter.java
@@ -41,11 +41,13 @@ public class SquidColorCenter extends IColorCenter.Skeleton<Color> {
 			/* Some filtering */
 			return filter.alter(red / 255f, green / 255f, blue / 255f, opacity / 255f);
 	}
-    public Color get(Color c)
+    @Override
+	public Color filter(Color c)
     {
         if(c == null)
             return Color.CLEAR;
-        return get(Math.round(c.r * 255f), Math.round(c.g * 255f), Math.round(c.b * 255f), Math.round(c.a * 255f));
+        else
+        	return super.filter(c);
     }
     public Color get(long c)
     {
@@ -102,7 +104,7 @@ public class SquidColorCenter extends IColorCenter.Skeleton<Color> {
     @Override
     public String toString() {
         return "SquidColorCenter{" +
-                "filter=" + filter.getClass().getSimpleName() +
+                "filter=" + (filter == null ? "null" : filter.getClass().getSimpleName()) +
                 '}';
     }
 }

--- a/squidlib/src/main/java/squidpony/squidgrid/gui/gdx/TextCellFactory.java
+++ b/squidlib/src/main/java/squidpony/squidgrid/gui/gdx/TextCellFactory.java
@@ -12,6 +12,8 @@ import com.badlogic.gdx.scenes.scene2d.ui.Image;
 import com.badlogic.gdx.scenes.scene2d.ui.Label;
 import com.badlogic.gdx.utils.Align;
 
+import squidpony.IColorCenter;
+
 /**
  * Class for creating text blocks.
  *
@@ -42,7 +44,7 @@ public class TextCellFactory {
     protected BitmapFont bmpFont = null;
     protected Texture block = null;
     protected String fitting = SQUID_FITTING;
-    protected SquidColorCenter scc;
+    protected IColorCenter<Color> scc;
     protected int leftPadding = 0, rightPadding = 0, topPadding = 0, bottomPadding = 0;
     protected int width = 1, height = 1;
     private boolean initialized = false;
@@ -374,6 +376,23 @@ public class TextCellFactory {
         bottomPadding = padding;
         return this;
     }
+
+	/**
+	 * @param icc
+	 *            The color center to use. Should not be {@code null}.
+	 * @return {@code this}
+	 * @throws NullPointerException
+	 *             If {@code icc} is {@code null}.
+	 */
+	public TextCellFactory setColorCenter(IColorCenter<Color> icc) {
+		if (icc == null)
+			/* Better fail now than later */
+			throw new NullPointerException(
+					"The color center should not be null in " + getClass().getSimpleName());
+		this.scc = icc;
+		return this;
+	}
+
     /**
      * Returns true if this factory is fully initialized and ready to build text cells.
      * 
@@ -382,7 +401,6 @@ public class TextCellFactory {
     public boolean initialized() {
         return initialized;
     }
-
 
     /**
      * Returns true if the given character will fit inside the current cell
@@ -445,12 +463,12 @@ public class TextCellFactory {
             throw new IllegalStateException("This factory has not yet been initialized!");
         }
         if (s == null) {
-            Color orig = scc.get(batch.getColor());
+            Color orig = scc.filter(batch.getColor());
             batch.setColor(r, g, b, a);
             batch.draw(block, x, y - height, width, height);
             batch.setColor(orig);
         } else if(s.length() > 0 && s.charAt(0) == '\0') {
-            Color orig = scc.get(batch.getColor());
+            Color orig = scc.filter(batch.getColor());
             batch.setColor(r, g, b, a);
             batch.draw(block, x, y - height, width * s.length(), height);
             batch.setColor(orig);
@@ -477,12 +495,12 @@ public class TextCellFactory {
         bmpFont.setColor(color);
 
         if (s == null) {
-            Color orig = scc.get(batch.getColor());
+            Color orig = scc.filter(batch.getColor());
             batch.setColor(color);
             batch.draw(block, x, y - height, width, height);
             batch.setColor(orig);
         } else if(s.length() > 0 && s.charAt(0) == '\0') {
-            Color orig = scc.get(batch.getColor());
+            Color orig = scc.filter(batch.getColor());
             batch.setColor(color);
             batch.draw(block, x, y - height, width * s.length(), height);
             batch.setColor(orig);
@@ -531,12 +549,12 @@ public class TextCellFactory {
             throw new IllegalStateException("This factory has not yet been initialized!");
         }
         if (tr == null) {
-            Color orig = scc.get(batch.getColor());
+            Color orig = scc.filter(batch.getColor());
             batch.setColor(r, g, b, a);
             batch.draw(block, x, y - height, width, height);
             batch.setColor(orig);
         } else {
-            Color orig = scc.get(batch.getColor());
+            Color orig = scc.filter(batch.getColor());
             batch.setColor(r, g, b, a);
             batch.draw(tr, x, y - height, width, height);
             batch.setColor(orig);
@@ -561,12 +579,12 @@ public class TextCellFactory {
         bmpFont.setColor(color);
 
         if (tr == null) {
-            Color orig = scc.get(batch.getColor());
+            Color orig = scc.filter(batch.getColor());
             batch.setColor(color);
             batch.draw(block, x, y - height, width, height);
             batch.setColor(orig);
         } else {
-            Color orig = scc.get(batch.getColor());
+            Color orig = scc.filter(batch.getColor());
             batch.setColor(color);
             batch.draw(tr, x, y - height, width, height);
             batch.setColor(orig);
@@ -616,12 +634,12 @@ public class TextCellFactory {
             throw new IllegalStateException("This factory has not yet been initialized!");
         }
         if (tr == null) {
-            Color orig = scc.get(batch.getColor());
+            Color orig = scc.filter(batch.getColor());
             batch.setColor(r, g, b, a);
             batch.draw(block, x, y - height, width, height);
             batch.setColor(orig);
         } else {
-            Color orig = scc.get(batch.getColor());
+            Color orig = scc.filter(batch.getColor());
             batch.setColor(r, g, b, a);
             batch.draw(tr, x, y - height, width, height);
             batch.setColor(orig);
@@ -647,12 +665,12 @@ public class TextCellFactory {
         }
 
         if (tr == null) {
-            Color orig = scc.get(batch.getColor());
+            Color orig = scc.filter(batch.getColor());
             batch.setColor(color);
             batch.draw(block, x, y - height, width, height);
             batch.setColor(orig);
         } else {
-            Color orig = scc.get(batch.getColor());
+            Color orig = scc.filter(batch.getColor());
             batch.setColor(color);
             batch.draw(tr, x, y - height, width, height);
             batch.setColor(orig);

--- a/squidlib/src/test/java/squidpony/gdx/examples/EverythingDemo.java
+++ b/squidlib/src/test/java/squidpony/gdx/examples/EverythingDemo.java
@@ -120,7 +120,7 @@ public class EverythingDemo extends ApplicationAdapter {
             Coord monPos = dungeonGen.utility.randomCell(placement);
             placement = CoordPacker.removePacked(placement, monPos.x, monPos.y);
             monsters.put(display.animateActor(monPos.x, monPos.y, 'M',
-                    filteredCenter.get(display.getPalette().get(11))), 0);
+                    filteredCenter.filter(display.getPalette().get(11))), 0);
 
         }
         // your choice of FOV matters here.
@@ -133,7 +133,7 @@ public class EverythingDemo extends ApplicationAdapter {
         fovmap = fov.calculateFOV(res, pl.x, pl.y, 8, Radius.SQUARE);
 
         player = display.animateActor(pl.x, pl.y, Character.forDigit(health, 10),
-                filteredCenter.get(display.getPalette().get(30)));
+                filteredCenter.filter(display.getPalette().get(30)));
         cursor = Coord.get(-1, -1);
         toCursor = new ArrayList<Coord>(10);
         awaitedMoves = new ArrayList<Coord>(10);
@@ -146,8 +146,8 @@ public class EverythingDemo extends ApplicationAdapter {
         bgColor = SColor.DARK_SLATE_GRAY;
         for (int i = 0; i < width; i++) {
             for (int j = 0; j < height; j++) {
-                colors[i][j] = filteredCenter.get(palette.get(initialColors[i][j]));
-                bgColors[i][j] = filteredCenter.get(palette.get(initialBGColors[i][j]));
+                colors[i][j] = filteredCenter.filter(palette.get(initialColors[i][j]));
+                bgColors[i][j] = filteredCenter.filter(palette.get(initialBGColors[i][j]));
             }
         }
         lights = DungeonUtility.generateLightnessModifiers(bareDungeon, counter);
@@ -437,8 +437,7 @@ public class EverythingDemo extends ApplicationAdapter {
 
 		/* Prepare the String to display */
 		final IColoredString<Color> cs = new IColoredString.Impl<Color>();
-		final Color textColor = Color.WHITE;
-		cs.append("Still ", textColor);
+		cs.append("Still ", null);
         final Color nbColor;
         if (nbMonsters <= 1)
             /* Green */
@@ -450,7 +449,7 @@ public class EverythingDemo extends ApplicationAdapter {
             /* Red */
             nbColor = new Color(1, 0, 0, 1);
         cs.appendInt(nbMonsters, nbColor);
-        cs.append(String.format(" monster%s to kill", nbMonsters == 1 ? "" : "s"), textColor);
+        cs.append(String.format(" monster%s to kill", nbMonsters == 1 ? "" : "s"), null);
 
 		/* The panel's width */
 		final int w = cs.length();


### PR DESCRIPTION
…(Color) method to IColorCenter (renaming it filter on the way, as I think `get` was slightly misleading). This allows users that have their own IColorCenter (which is not a SquidColorCenter) to make the panels use it (hence avoiding the panels and the outside world to allocate each Color twice..) (such users would include me ;-). I haven't pushed lerp to IColorCenter, because it is less precise on the RGB representation; but this is only a problem for users that want their own IColorCenter and use SquidLayers (as that's where SquidPanel's lerp is called from)(see SquidPanel#put(int x, int y, char c, Color color, float colorMultiplier) on that topic).

I also made TextCellFactory depend on IColorCenter<Color> instead of SquidColorCenter (there was nothing to do here, just changing the type).

And I found why the '?' white text wasn't showing up in EverythingDemo, that's because the color was now retrieved using the color center, who was defaulting to Color.CLEAR when the requested color was null; but the `put` method for IColoredString in `SquidPanel` was telling that null was defaulted to the panel's default foreground color (which is Color.WHITE). Hence I made the code use the panel's default foreground color again.