### PR TITLE
Make RNG's class hierarchy Serializable

### DIFF
--- a/squidlib-util/src/main/java/squidpony/squidmath/DharmaRNG.java
+++ b/squidlib-util/src/main/java/squidpony/squidmath/DharmaRNG.java
@@ -34,7 +34,7 @@ import java.util.Random;
  */
 public class DharmaRNG extends RNG {
 
-    /** Used to tweak the generator toward high or low values. */
+	/** Used to tweak the generator toward high or low values. */
     private double fairness = 0.54;
 
     /** Running total for what this has actually produced. */
@@ -42,6 +42,8 @@ public class DharmaRNG extends RNG {
 
     /** Running total for what this would produce if it always produced a value equal to fairness. */
     private double baseline = 0.0;
+
+	private static final long serialVersionUID = -8919455766853811999L;
 
     /**
      * Constructs a DharmaRNG with a pseudo-random seed from Math.random().

--- a/squidlib-util/src/main/java/squidpony/squidmath/LightRNG.java
+++ b/squidlib-util/src/main/java/squidpony/squidmath/LightRNG.java
@@ -18,7 +18,7 @@ package squidpony.squidmath;
  */
 public class LightRNG implements RandomnessSource, StatefulRandomness
 {
-    /** 2 raised to the 53, - 1. */
+	/** 2 raised to the 53, - 1. */
     private static final long DOUBLE_MASK = ( 1L << 53 ) - 1;
     /** 2 raised to the -53. */
     private static final double NORM_53 = 1. / ( 1L << 53 );
@@ -26,6 +26,8 @@ public class LightRNG implements RandomnessSource, StatefulRandomness
     private static final long FLOAT_MASK = ( 1L << 24 ) - 1;
     /** 2 raised to the -24. */
     private static final double NORM_24 = 1. / ( 1L << 24 );
+
+	private static final long serialVersionUID = -1656615589113474497L;
 
     public long state; /* The state can be seeded with any value. */
 

--- a/squidlib-util/src/main/java/squidpony/squidmath/MersenneTwister.java
+++ b/squidlib-util/src/main/java/squidpony/squidmath/MersenneTwister.java
@@ -18,7 +18,7 @@ import java.util.concurrent.locks.ReentrantLock;
  */
 public class MersenneTwister implements RandomnessSource {
 
-    // The actual seed size isn't that important, but it should be a multiple of 4.
+	// The actual seed size isn't that important, but it should be a multiple of 4.
     private static final int SEED_SIZE_BYTES = 8;
     // Magic numbers from original C version.
     private static final int N = 624;
@@ -38,6 +38,8 @@ public class MersenneTwister implements RandomnessSource {
     private final int[] mt = new int[N]; // State vector.
     private int mtIndex = 0; // Index into state vector.    
     private static final int BITWISE_BYTE_TO_INT = 0x000000FF;
+
+	private static final long serialVersionUID = 217351968847857679L;
 
     /**
      * Creates a new RNG and seeds it using the default seeding strategy.

--- a/squidlib-util/src/main/java/squidpony/squidmath/PermutedRNG.java
+++ b/squidlib-util/src/main/java/squidpony/squidmath/PermutedRNG.java
@@ -21,7 +21,7 @@ package squidpony.squidmath;
  */
 public class PermutedRNG implements RandomnessSource, StatefulRandomness
 {
-    /** 2 raised to the 53, - 1. */
+	/** 2 raised to the 53, - 1. */
     private static final long DOUBLE_MASK = ( 1L << 53 ) - 1;
     /** 2 raised to the -53. */
     private static final double NORM_53 = 1. / ( 1L << 53 );
@@ -33,6 +33,8 @@ public class PermutedRNG implements RandomnessSource, StatefulRandomness
      * The state can be seeded with any value.
      */
     public long state;
+
+	private static final long serialVersionUID = -2319339396218218531L;
 
     /** Creates a new generator seeded using Math.random. */
     public PermutedRNG() {

--- a/squidlib-util/src/main/java/squidpony/squidmath/RNG.java
+++ b/squidlib-util/src/main/java/squidpony/squidmath/RNG.java
@@ -1,5 +1,6 @@
 package squidpony.squidmath;
 
+import java.io.Serializable;
 import java.util.*;
 
 /**
@@ -11,13 +12,15 @@ import java.util.*;
  *
  * @author Eben Howard - http://squidpony.com - howard@squidpony.com
  */
-public class RNG {
+public class RNG implements Serializable {
 
-    protected static final double DOUBLE_UNIT = 1.0 / (1L << 53);
+	protected static final double DOUBLE_UNIT = 1.0 / (1L << 53);
     protected RandomnessSource random;
     protected double nextNextGaussian;
     protected boolean haveNextNextGaussian = false;
     private Random ran = null;
+
+	private static final long serialVersionUID = 5716284182286645149L;
 
     /**
      * Default constructor uses Mersenne Twister, which is of high quality and

--- a/squidlib-util/src/main/java/squidpony/squidmath/RandomnessSource.java
+++ b/squidlib-util/src/main/java/squidpony/squidmath/RandomnessSource.java
@@ -1,5 +1,7 @@
 package squidpony.squidmath;
 
+import java.io.Serializable;
+
 /**
  * This interface defines the interactions required of a random number
  * generator. It is a replacement for Java's built-in Random because for
@@ -7,7 +9,7 @@ package squidpony.squidmath;
  *
  * @author Eben Howard - http://squidpony.com - howard@squidpony.com
  */
-public interface RandomnessSource {
+public interface RandomnessSource extends Serializable {
 
     /**
      * Using this method, any algorithm that might use the built-in Java Random

--- a/squidlib-util/src/main/java/squidpony/squidmath/SobolQRNG.java
+++ b/squidlib-util/src/main/java/squidpony/squidmath/SobolQRNG.java
@@ -53,7 +53,7 @@ import java.util.StringTokenizer;
  */
 public class SobolQRNG implements RandomnessSource {
 
-    /** The number of bits to use. */
+	/** The number of bits to use. */
     private static final int BITS = 52;
 
     /** The scaling factor. */
@@ -67,6 +67,8 @@ public class SobolQRNG implements RandomnessSource {
 
     /** Character set for file input. */
     private static final String FILE_CHARSET = "US-ASCII";
+
+	private static final long serialVersionUID = -6759002780425873173L;
 
     /** Space dimension. */
     private final int dimension;

--- a/squidlib-util/src/main/java/squidpony/squidmath/StatefulRNG.java
+++ b/squidlib-util/src/main/java/squidpony/squidmath/StatefulRNG.java
@@ -9,7 +9,10 @@ import java.util.Random;
  * Created by Tommy Ettinger on 9/15/2015.
  */
 public class StatefulRNG extends RNG {
-    public StatefulRNG() {
+
+	private static final long serialVersionUID = 4801506898212937160L;
+
+	public StatefulRNG() {
         super(new LightRNG());
     }
 

--- a/squidlib-util/src/main/java/squidpony/squidmath/XorRNG.java
+++ b/squidlib-util/src/main/java/squidpony/squidmath/XorRNG.java
@@ -17,10 +17,13 @@ package squidpony.squidmath;
  */
 public class XorRNG implements RandomnessSource {
 
-    private static final long DOUBLE_MASK = (1L << 53) - 1;
+	private static final long DOUBLE_MASK = (1L << 53) - 1;
     private static final double NORM_53 = 1. / (1L << 53);
     private static final long FLOAT_MASK = (1L << 24) - 1;
     private static final double NORM_24 = 1. / (1L << 24);
+
+	private static final long serialVersionUID = 1263134736171610359L;
+
     private long state0, state1;
 
     /**


### PR DESCRIPTION
Nothing really interesting here. I needed RNG to be Serializable to implement saves in my roguelike. So far so good, although my test is limited: I only use RNG itself (not any of its subtypes) and did not test stability through serialization/deserialization.