### PR TITLE
Add option to use AssetManager in TextCellFactory, to avoid redundant…

### DIFF
--- a/squidlib-util/src/main/java/squidpony/panel/IColoredString.java
+++ b/squidlib-util/src/main/java/squidpony/panel/IColoredString.java
@@ -121,6 +121,17 @@ public interface IColoredString<T> extends Iterable<IColoredString.Bucket<T>> {
 		 * 
 		 * @return {@code new Impl(s, t)}.
 		 */
+		public static <T> IColoredString.Impl<T> create() {
+			return new IColoredString.Impl<T>("", null);
+		}
+
+
+		/**
+		 * A static constructor, to avoid having to write {@code <T>} in the
+		 * caller.
+		 * 
+		 * @return {@code new Impl(s, t)}.
+		 */
 		public static <T> IColoredString.Impl<T> create(String s, /* @Nullable */ T t) {
 			return new IColoredString.Impl<T>(s, t);
 		}

--- a/squidlib-util/src/main/java/squidpony/squidgrid/Direction.java
+++ b/squidlib-util/src/main/java/squidpony/squidgrid/Direction.java
@@ -1,5 +1,7 @@
 package squidpony.squidgrid;
 
+import squidpony.squidmath.Coord;
+
 /**
  * Represents the eight grid directions and the deltaX, deltaY values associated
  * with those directions.
@@ -119,6 +121,18 @@ public enum Direction {
         return LEFT;
 
     }
+
+	/**
+	 * @param from
+	 *            The starting point.
+	 * @param to
+	 *            The desired point to reach.
+	 * @return The direction to follow to go from {@code from} to {@code to}. It
+	 *         can be cardinal or diagonal.
+	 */
+	public static Direction toGoTo(Coord from, Coord to) {
+		return getDirection(to.x - from.x, to.y - from.y);
+	}
 
     /**
      * Returns the Direction one step clockwise including diagonals.

--- a/squidlib/src/main/java/squidpony/squidgrid/gui/gdx/ButtonsPanel.java
+++ b/squidlib/src/main/java/squidpony/squidgrid/gui/gdx/ButtonsPanel.java
@@ -283,7 +283,7 @@ public abstract class ButtonsPanel<T extends Color> extends GroupCombinedPanel<T
 	 * @throws IllegalStateException
 	 *             In various cases of errors regarding sizes of panels.
 	 */
-	public ButtonsPanel(List<IColoredString<T>> buttonTexts) {
+	public ButtonsPanel(/* Nullable */ List<IColoredString<T>> buttonTexts) {
 		if (buttonTexts != null) {
 			this.buttonsTexts = new ArrayList<IColoredString<T>>(buttonTexts.size());
 			this.buttonsTexts.addAll(buttonTexts);
@@ -319,6 +319,13 @@ public abstract class ButtonsPanel<T extends Color> extends GroupCombinedPanel<T
 	 *         <p>
 	 *         See {@link #y_gdxToSquid()} to configure the processor's
 	 *         behavior.
+	 *         </p>
+	 * 
+	 *         <p>
+	 *         If this panel is behind a {@link Stage} (i.e. you're not setting
+	 *         the returned processor to {@link Gdx#input}) and you want it to
+	 *         receive keyboard events, don't forget to call
+	 *         {@link Stage#setKeyboardFocus(Actor)} by giving {@code this}.
 	 *         </p>
 	 * @throws NullPointerException
 	 *             If the text of buttons wasn't given at creation time, and
@@ -720,7 +727,7 @@ public abstract class ButtonsPanel<T extends Color> extends GroupCombinedPanel<T
 				for (int i = 0; i < bound; i++) {
 					final char c = bucketText.charAt(i);
 					if (set || shortcuts.containsKey(Character.toLowerCase(c))
-							|| !Character.isAlphabetic(c)) {
+							|| !Character.isLetter(c)) {
 						/*
 						 * Shortcut already used or we went into the 'else'
 						 * already, or character is inadequate.

--- a/squidlib/src/main/java/squidpony/squidgrid/gui/gdx/UIUtil.java
+++ b/squidlib/src/main/java/squidpony/squidgrid/gui/gdx/UIUtil.java
@@ -62,6 +62,12 @@ public class UIUtil {
 	 *            The width of the button considered.
 	 * @param height
 	 *            The width of the button considered.
+	 * @param margin
+	 *            The size of the margin to draw.
+	 * @param color
+	 *            The color to draw
+	 * @param cornerStyle
+	 *            The style with which to draw the margins
 	 */
 	public static void drawMarginsAround(float botLeftX, float botLeftY, int width, int height, int margin,
 			Color color, CornerStyle cornerStyle) {


### PR DESCRIPTION
… loading of font files when multiple TextCellFactories are used. Add an option to SquidPanel.tint method to delay its execution. Add SquidPanel.fade method (a new animation). Removed useless call to Actions.delay in SquidPanel.tint's implementation. Extract SquidPanel's clamping of duration to a method (to avoid duplications, and to allow subclassers to change it). Avoid calling Charachter.isAlphabetic in ButtonsPanel, that doesn't exit in jdk1.6 (this causes a problem to compile to gwt).

The AssetManager business is only useful for people that build many panels, and don't want to have one rule-them-all TextCellFactory; but that still want to avoid loading a font file from disk twice (because that can be slow). For example, users of SquidLayers don't need it, because SquidLayers uses a single TextCellFactory for all its SquidPanels.

The AssetManager is useful when implementing zoom in/zoom out on phones, if you use different font files at different zoom levels. If the user zooms/unzooms quite often (and often going back to the same size), the GUI answer will quickly be smoother, because font files are no longer loaded (and that's the thing taking time).