### PR TITLE
Casting math operands before assignment

### DIFF
--- a/squidlib-util/src/main/java/squidpony/squidai/BeamAOE.java
+++ b/squidlib-util/src/main/java/squidpony/squidai/BeamAOE.java
@@ -401,7 +401,7 @@ public class BeamAOE implements AOE {
                 }
             }
         }
-        double bestQuality = 99999 * ts.length;
+        double bestQuality = 99999D * ts.length;
         double[][] qualityMap = new double[dungeon.length][dungeon[0].length];
         for (int x = 0; x < qualityMap.length; x++) {
             for (int y = 0; y < qualityMap[x].length; y++) {
@@ -605,7 +605,7 @@ public class BeamAOE implements AOE {
             dm.resetMap();
             dm.clearGoals();
         }
-        double bestQuality = 99999 * lts.length + 399999 * pts.length;
+        double bestQuality = 99999D * lts.length + 399999D * pts.length;
         double[][] qualityMap = new double[dungeon.length][dungeon[0].length];
         for (int x = 0; x < qualityMap.length; x++) {
             for (int y = 0; y < qualityMap[x].length; y++) {

--- a/squidlib-util/src/main/java/squidpony/squidai/BlastAOE.java
+++ b/squidlib-util/src/main/java/squidpony/squidai/BlastAOE.java
@@ -191,7 +191,7 @@ public class BlastAOE implements AOE {
                 }
             }
         }
-        double bestQuality = 99999 * ts.length;
+        double bestQuality = 99999D * ts.length;
         double[][] qualityMap = new double[dungeon.length][dungeon[0].length];
         for (int x = 0; x < qualityMap.length; x++) {
             for (int y = 0; y < qualityMap[x].length; y++) {
@@ -380,7 +380,7 @@ public class BlastAOE implements AOE {
                 }
             }
         }
-        double bestQuality = 99999 * lts.length + 399999 * pts.length;
+        double bestQuality = 99999D * lts.length + 399999D * pts.length;
         double[][] qualityMap = new double[dungeon.length][dungeon[0].length];
         for (int x = 0; x < qualityMap.length; x++) {
             for (int y = 0; y < qualityMap[x].length; y++) {

--- a/squidlib-util/src/main/java/squidpony/squidai/BurstAOE.java
+++ b/squidlib-util/src/main/java/squidpony/squidai/BurstAOE.java
@@ -184,7 +184,7 @@ public class BurstAOE implements AOE {
                 }
             }
         }
-        double bestQuality = 99999 * ts.length;
+        double bestQuality = 99999D * ts.length;
         double[][] qualityMap = new double[dungeon.length][dungeon[0].length];
         for (int x = 0; x < qualityMap.length; x++) {
             for (int y = 0; y < qualityMap[x].length; y++) {
@@ -376,7 +376,7 @@ public class BurstAOE implements AOE {
             dm.resetMap();
             dm.clearGoals();
         }
-        double bestQuality = 99999 * lts.length + 399999 * pts.length;
+        double bestQuality = 99999D * lts.length + 399999D * pts.length;
         double[][] qualityMap = new double[dungeon.length][dungeon[0].length];
         for (int x = 0; x < qualityMap.length; x++) {
             for (int y = 0; y < qualityMap[x].length; y++) {

--- a/squidlib-util/src/main/java/squidpony/squidai/CloudAOE.java
+++ b/squidlib-util/src/main/java/squidpony/squidai/CloudAOE.java
@@ -288,7 +288,7 @@ public class CloudAOE implements AOE {
             dm.resetMap();
             dm.clearGoals();
         }
-        double bestQuality = 99999 * ts.length;
+        double bestQuality = 99999D * ts.length;
         double[][] qualityMap = new double[dungeon.length][dungeon[0].length];
         for (int x = 0; x < qualityMap.length; x++) {
             for (int y = 0; y < qualityMap[x].length; y++) {
@@ -487,7 +487,7 @@ public class CloudAOE implements AOE {
             dm.resetMap();
             dm.clearGoals();
         }
-        double bestQuality = 99999 * lts.length + 399999 * pts.length;
+        double bestQuality = 99999D * lts.length + 399999D * pts.length;
         double[][] qualityMap = new double[dungeon.length][dungeon[0].length];
         for (int x = 0; x < qualityMap.length; x++) {
             for (int y = 0; y < qualityMap[x].length; y++) {

--- a/squidlib-util/src/main/java/squidpony/squidai/ConeAOE.java
+++ b/squidlib-util/src/main/java/squidpony/squidai/ConeAOE.java
@@ -289,7 +289,7 @@ public class ConeAOE implements AOE {
                 }
             }
         }
-        double bestQuality = 99999 * ts.length;
+        double bestQuality = 99999D * ts.length;
         double[][] qualityMap = new double[dungeon.length][dungeon[0].length];
         for (int x = 0; x < qualityMap.length; x++) {
             for (int y = 0; y < qualityMap[x].length; y++) {
@@ -467,7 +467,7 @@ public class ConeAOE implements AOE {
                 }
             }
         }
-        double bestQuality = 99999 * lts.length + 399999 * pts.length;
+        double bestQuality = 99999D * lts.length + 399999D * pts.length;
         double[][] qualityMap = new double[dungeon.length][dungeon[0].length];
         for (int x = 0; x < qualityMap.length; x++) {
             for (int y = 0; y < qualityMap[x].length; y++) {

--- a/squidlib-util/src/main/java/squidpony/squidai/LineAOE.java
+++ b/squidlib-util/src/main/java/squidpony/squidai/LineAOE.java
@@ -359,7 +359,7 @@ public class LineAOE implements AOE {
             dm.resetMap();
             dm.clearGoals();
         }
-        double bestQuality = 99999 * ts.length;
+        double bestQuality = 99999D * ts.length;
         double[][] qualityMap = new double[dungeon.length][dungeon[0].length];
         for (int x = 0; x < qualityMap.length; x++) {
             for (int y = 0; y < qualityMap[x].length; y++) {
@@ -559,7 +559,7 @@ public class LineAOE implements AOE {
             dm.resetMap();
             dm.clearGoals();
         }
-        double bestQuality = 99999 * lts.length + 399999 * pts.length;
+        double bestQuality = 99999D * lts.length + 399999D * pts.length;
         double[][] qualityMap = new double[dungeon.length][dungeon[0].length];
         for (int x = 0; x < qualityMap.length; x++) {
             for (int y = 0; y < qualityMap[x].length; y++) {

--- a/squidlib-util/src/main/java/squidpony/squidgrid/mapping/MetsaMapFactory.java
+++ b/squidlib-util/src/main/java/squidpony/squidgrid/mapping/MetsaMapFactory.java
@@ -214,7 +214,7 @@ public class MetsaMapFactory {
                 px = rng.between(0, width);
                 py = rng.between(0, height);
             }
-            cities.add(Coord.get(4 * round(px / 4), 4 * round(py / 4)));
+            cities.add(Coord.get(4 * round(px / 4F), 4 * round(py / 4F)));
         }
         return weightedMap;
     }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2184 - “ Math operands should be cast before assignment”. You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S2184
Please let me know if you have any questions.
Ayman Abdelghany.