### PR TITLE
Simplify the generics declaration by using the diamond operator ("<>"……) to reduce the verbosity of generics code.

### DIFF
--- a/squidlib-util/src/main/java/squidpony/FakeLanguageGen.java
+++ b/squidlib-util/src/main/java/squidpony/FakeLanguageGen.java
@@ -541,7 +541,7 @@ public class FakeLanguageGen implements Serializable {
         this.vowelSplitters = vowelSplitters;
         this.closingSyllables = closingSyllables;
 
-        this.syllableFrequencies = new LinkedHashMap<Integer, Double>(syllableLengths.length);
+        this.syllableFrequencies = new LinkedHashMap<>(syllableLengths.length);
         for (int i = 0; i < syllableLengths.length && i < syllableFrequencies.length; i++) {
             this.syllableFrequencies.put(syllableLengths[i], syllableFrequencies[i]);
         }
@@ -1088,7 +1088,7 @@ public class FakeLanguageGen implements Serializable {
                         Math.max(0.0, Math.min(1.0, (other.syllableEndFrequency - syllableEndFrequency)))),
                 splitters = merge1000(rng, vowelSplitters, other.vowelSplitters, otherInfluence);
 
-        LinkedHashMap<Integer, Double> freqs = new LinkedHashMap<Integer, Double>(syllableFrequencies);
+        LinkedHashMap<Integer, Double> freqs = new LinkedHashMap<>(syllableFrequencies);
         for (Map.Entry<Integer, Double> kv : other.syllableFrequencies.entrySet()) {
             if (freqs.containsKey(kv.getKey()))
                 freqs.put(kv.getKey(), kv.getValue() + freqs.get(kv.getKey()));

--- a/squidlib-util/src/main/java/squidpony/IColorCenter.java
+++ b/squidlib-util/src/main/java/squidpony/IColorCenter.java
@@ -185,7 +185,7 @@ public interface IColorCenter<T> {
 	 */
 	abstract class Skeleton<T> implements IColorCenter<T> {
 
-		private final Map<Long, T> cache = new HashMap<Long, T>(256);
+		private final Map<Long, T> cache = new HashMap<>(256);
 
 		protected /*Nullable*/ IFilter<T> filter;
 

--- a/squidlib-util/src/main/java/squidpony/MonsterGen.java
+++ b/squidlib-util/src/main/java/squidpony/MonsterGen.java
@@ -61,13 +61,13 @@ public class MonsterGen {
                 mainForm = unknown;
             else
                 mainForm = other.name;
-            parts = new LinkedHashMap<String, List<String>>(other.parts);
-            List<String> oldParts = new ArrayList<String>(parts.remove(mainForm));
+            parts = new LinkedHashMap<>(other.parts);
+            List<String> oldParts = new ArrayList<>(parts.remove(mainForm));
             parts.put(name, oldParts);
-            unsaidAdjectives = new LinkedHashSet<String>(other.unsaidAdjectives);
-            wholeAdjectives = new LinkedHashSet<String>(other.wholeAdjectives);
-            powerAdjectives = new LinkedHashSet<String>(other.powerAdjectives);
-            powerPhrases = new LinkedHashSet<String>(other.powerPhrases);
+            unsaidAdjectives = new LinkedHashSet<>(other.unsaidAdjectives);
+            wholeAdjectives = new LinkedHashSet<>(other.wholeAdjectives);
+            powerAdjectives = new LinkedHashSet<>(other.powerAdjectives);
+            powerPhrases = new LinkedHashSet<>(other.powerPhrases);
         }
 
         /**
@@ -104,12 +104,12 @@ public class MonsterGen {
                 mainForm = unknown;
             else
                 mainForm = name;
-            parts = new LinkedHashMap<String, List<String>>();
-            unsaidAdjectives = new LinkedHashSet<String>();
-            wholeAdjectives = new LinkedHashSet<String>();
-            powerAdjectives = new LinkedHashSet<String>();
-            powerPhrases = new LinkedHashSet<String>();
-            ArrayList<String> selfParts = new ArrayList<String>();
+            parts = new LinkedHashMap<>();
+            unsaidAdjectives = new LinkedHashSet<>();
+            wholeAdjectives = new LinkedHashSet<>();
+            powerAdjectives = new LinkedHashSet<>();
+            powerPhrases = new LinkedHashSet<>();
+            ArrayList<String> selfParts = new ArrayList<>();
             int t = 0;
             for (; t < terms.length; t++) {
                 if(terms[t].equals(";"))
@@ -163,7 +163,7 @@ public class MonsterGen {
             else
                 sb.append('a');
             int i = 0;
-            LinkedHashSet<String> allAdjectives = new LinkedHashSet<String>(wholeAdjectives);
+            LinkedHashSet<String> allAdjectives = new LinkedHashSet<>(wholeAdjectives);
             if(unknown != null)
                 allAdjectives.addAll(unsaidAdjectives);
             allAdjectives.addAll(powerAdjectives);
@@ -246,7 +246,7 @@ public class MonsterGen {
                 sb.append('a');
             int i = 0;
 
-            LinkedHashSet<String> allAdjectives = new LinkedHashSet<String>(wholeAdjectives);
+            LinkedHashSet<String> allAdjectives = new LinkedHashSet<>(wholeAdjectives);
             if(unknown != null)
                 allAdjectives.addAll(unsaidAdjectives);
             for(String adj : allAdjectives)

--- a/squidlib-util/src/main/java/squidpony/panel/IColoredString.java
+++ b/squidlib-util/src/main/java/squidpony/panel/IColoredString.java
@@ -145,7 +145,7 @@ public interface IColoredString<T> extends Iterable<IColoredString.Bucket<T>> {
 		 * An empty instance.
 		 */
 		public Impl() {
-			fragments = new LinkedList<Bucket<T>>();
+			fragments = new LinkedList<>();
 		}
 
 		/**
@@ -169,7 +169,7 @@ public interface IColoredString<T> extends Iterable<IColoredString.Bucket<T>> {
 		 * @return {@code new Impl(s, t)}.
 		 */
 		public static <T> IColoredString.Impl<T> create() {
-			return new IColoredString.Impl<T>("", null);
+			return new IColoredString.Impl<>("", null);
 		}
 
 		/**
@@ -179,7 +179,7 @@ public interface IColoredString<T> extends Iterable<IColoredString.Bucket<T>> {
 		 * @return {@code new Impl(s, t)}.
 		 */
 		public static <T> IColoredString.Impl<T> create(String s, /* @Nullable */ T t) {
-			return new IColoredString.Impl<T>(s, t);
+			return new IColoredString.Impl<>(s, t);
 		}
 
 		@Override
@@ -193,7 +193,7 @@ public interface IColoredString<T> extends Iterable<IColoredString.Bucket<T>> {
 				return;
 
 			if (fragments.isEmpty())
-				fragments.add(new Bucket<T>(text, color));
+				fragments.add(new Bucket<>(text, color));
 			else {
 				final Bucket<T> last = fragments.getLast();
 				if (equals(last.color, color)) {
@@ -202,7 +202,7 @@ public interface IColoredString<T> extends Iterable<IColoredString.Bucket<T>> {
 					fragments.removeLast();
 					fragments.addLast(novel);
 				} else
-					fragments.add(new Bucket<T>(text, color));
+					fragments.add(new Bucket<>(text, color));
 			}
 		}
 
@@ -225,7 +225,7 @@ public interface IColoredString<T> extends Iterable<IColoredString.Bucket<T>> {
 		}
 
 		public void append(Bucket<T> bucket) {
-			this.fragments.add(new Bucket<T>(bucket.getText(), bucket.getColor()));
+			this.fragments.add(new Bucket<>(bucket.getText(), bucket.getColor()));
 		}
 
 		@Override
@@ -270,12 +270,12 @@ public interface IColoredString<T> extends Iterable<IColoredString.Bucket<T>> {
 			if (width == 0) {
 				/* Really, you should not rely on this behavior */
 				System.err.println("Cannot wrap string in empty display");
-				final List<IColoredString<T>> result = new LinkedList<IColoredString<T>>();
+				final List<IColoredString<T>> result = new LinkedList<>();
 				result.add(this);
 				return result;
 			}
 
-			final List<IColoredString<T>> result = new ArrayList<IColoredString<T>>();
+			final List<IColoredString<T>> result = new ArrayList<>();
 			if (isEmpty()) {
 				/*
 				 * Catch this case early on, as empty lines are eaten below (see
@@ -338,7 +338,7 @@ public interface IColoredString<T> extends Iterable<IColoredString.Bucket<T>> {
 							 * new line immediately.
 							 */
 							/* Add */
-							result.add(new Impl<T>(chunk, color));
+							result.add(new Impl<>(chunk, color));
 							/* Prepare for next rolls */
 							current = create();
 							/* Reinit size */
@@ -622,7 +622,7 @@ public interface IColoredString<T> extends Iterable<IColoredString.Bucket<T>> {
 				/* Let's save an allocation */
 				return this;
 			else
-				return new Bucket<T>(this.text + text, color);
+				return new Bucket<>(this.text + text, color);
 		}
 
 		public Bucket<T> setLength(int l) {
@@ -630,7 +630,7 @@ public interface IColoredString<T> extends Iterable<IColoredString.Bucket<T>> {
 			if (here <= l)
 				return this;
 			else
-				return new Bucket<T>(text.substring(0, l), color);
+				return new Bucket<>(text.substring(0, l), color);
 		}
 
 		/**

--- a/squidlib-util/src/main/java/squidpony/squidai/BeamAOE.java
+++ b/squidlib-util/src/main/java/squidpony/squidai/BeamAOE.java
@@ -304,13 +304,13 @@ public class BeamAOE implements AOE {
     @Override
     public LinkedHashMap<Coord, ArrayList<Coord>> idealLocations(Set<Coord> targets, Set<Coord> requiredExclusions) {
         if(targets == null)
-            return new LinkedHashMap<Coord, ArrayList<Coord>>();
-        if(requiredExclusions == null) requiredExclusions = new LinkedHashSet<Coord>();
+            return new LinkedHashMap<>();
+        if(requiredExclusions == null) requiredExclusions = new LinkedHashSet<>();
 
         //requiredExclusions.remove(origin);
 
         int totalTargets = targets.size();
-        LinkedHashMap<Coord, ArrayList<Coord>> bestPoints = new LinkedHashMap<Coord, ArrayList<Coord>>(totalTargets * 8);
+        LinkedHashMap<Coord, ArrayList<Coord>> bestPoints = new LinkedHashMap<>(totalTargets * 8);
 
         if(totalTargets == 0)
             return bestPoints;
@@ -414,7 +414,7 @@ public class BeamAOE implements AOE {
                 }
                 if(qualityMap[x][y] < bestQuality)
                 {
-                    ArrayList<Coord> ap = new ArrayList<Coord>();
+                    ArrayList<Coord> ap = new ArrayList<>();
 
                     for (int i = 0; i < ts.length && i < 63; ++i) {
                         if((bits & (1 << i)) != 0)
@@ -429,7 +429,7 @@ public class BeamAOE implements AOE {
                 }
                 else if(qualityMap[x][y] == bestQuality)
                 {
-                    ArrayList<Coord> ap = new ArrayList<Coord>();
+                    ArrayList<Coord> ap = new ArrayList<>();
 
                     for (int i = 0; i < ts.length && i < 63; ++i) {
                         if((bits & (1 << i)) != 0)
@@ -450,11 +450,11 @@ public class BeamAOE implements AOE {
     public LinkedHashMap<Coord, ArrayList<Coord>> idealLocations(Set<Coord> priorityTargets, Set<Coord> lesserTargets, Set<Coord> requiredExclusions) {
         if(priorityTargets == null)
             return idealLocations(lesserTargets, requiredExclusions);
-        if(requiredExclusions == null) requiredExclusions = new LinkedHashSet<Coord>();
+        if(requiredExclusions == null) requiredExclusions = new LinkedHashSet<>();
 
         //requiredExclusions.remove(origin);
         int totalTargets = priorityTargets.size() + lesserTargets.size();
-        LinkedHashMap<Coord, ArrayList<Coord>> bestPoints = new LinkedHashMap<Coord, ArrayList<Coord>>(totalTargets * 8);
+        LinkedHashMap<Coord, ArrayList<Coord>> bestPoints = new LinkedHashMap<>(totalTargets * 8);
 
         if(totalTargets == 0)
             return bestPoints;
@@ -623,7 +623,7 @@ public class BeamAOE implements AOE {
                 }
                 if(qualityMap[x][y] < bestQuality)
                 {
-                    ArrayList<Coord> ap = new ArrayList<Coord>();
+                    ArrayList<Coord> ap = new ArrayList<>();
 
                     for (int i = 0; i < pts.length && i < 63; ++i) {
                         if((pbits & (1 << i)) != 0)
@@ -642,7 +642,7 @@ public class BeamAOE implements AOE {
                 }
                 else if(qualityMap[x][y] == bestQuality)
                 {
-                    ArrayList<Coord> ap = new ArrayList<Coord>();
+                    ArrayList<Coord> ap = new ArrayList<>();
 
                     for (int i = 0; i < pts.length && i < 63; ++i) {
                         if ((pbits & (1 << i)) != 0) {

--- a/squidlib-util/src/main/java/squidpony/squidai/BlastAOE.java
+++ b/squidlib-util/src/main/java/squidpony/squidai/BlastAOE.java
@@ -93,12 +93,12 @@ public class BlastAOE implements AOE {
     @Override
     public LinkedHashMap<Coord, ArrayList<Coord>> idealLocations(Set<Coord> targets, Set<Coord> requiredExclusions) {
         if(targets == null)
-            return new LinkedHashMap<Coord, ArrayList<Coord>>();
-        if(requiredExclusions == null) requiredExclusions = new LinkedHashSet<Coord>();
+            return new LinkedHashMap<>();
+        if(requiredExclusions == null) requiredExclusions = new LinkedHashSet<>();
 
         //requiredExclusions.remove(origin);
         int totalTargets = targets.size();
-        LinkedHashMap<Coord, ArrayList<Coord>> bestPoints = new LinkedHashMap<Coord, ArrayList<Coord>>(totalTargets * 8);
+        LinkedHashMap<Coord, ArrayList<Coord>> bestPoints = new LinkedHashMap<>(totalTargets * 8);
 
         if(totalTargets == 0)
             return bestPoints;
@@ -107,7 +107,7 @@ public class BlastAOE implements AOE {
         {
             for(Coord p : targets)
             {
-                ArrayList<Coord> ap = new ArrayList<Coord>();
+                ArrayList<Coord> ap = new ArrayList<>();
                 ap.add(p);
                 bestPoints.put(p, ap);
             }
@@ -204,7 +204,7 @@ public class BlastAOE implements AOE {
                 }
                 if(qualityMap[x][y] < bestQuality)
                 {
-                    ArrayList<Coord> ap = new ArrayList<Coord>();
+                    ArrayList<Coord> ap = new ArrayList<>();
 
                     for (int i = 0; i < ts.length && i < 63; ++i) {
                         if((bits & (1 << i)) != 0)
@@ -218,7 +218,7 @@ public class BlastAOE implements AOE {
                     }
                 }
                 else if(qualityMap[x][y] == bestQuality) {
-                    ArrayList<Coord> ap = new ArrayList<Coord>();
+                    ArrayList<Coord> ap = new ArrayList<>();
 
                     for (int i = 0; i < ts.length && i < 63; ++i) {
                         if ((bits & (1 << i)) != 0)
@@ -238,11 +238,11 @@ public class BlastAOE implements AOE {
     public LinkedHashMap<Coord, ArrayList<Coord>> idealLocations(Set<Coord> priorityTargets, Set<Coord> lesserTargets, Set<Coord> requiredExclusions) {
         if(priorityTargets == null)
             return idealLocations(lesserTargets, requiredExclusions);
-        if(requiredExclusions == null) requiredExclusions = new LinkedHashSet<Coord>();
+        if(requiredExclusions == null) requiredExclusions = new LinkedHashSet<>();
 
         //requiredExclusions.remove(origin);
         int totalTargets = priorityTargets.size() + lesserTargets.size();
-        LinkedHashMap<Coord, ArrayList<Coord>> bestPoints = new LinkedHashMap<Coord, ArrayList<Coord>>(totalTargets * 8);
+        LinkedHashMap<Coord, ArrayList<Coord>> bestPoints = new LinkedHashMap<>(totalTargets * 8);
 
         if(totalTargets == 0)
             return bestPoints;
@@ -251,7 +251,7 @@ public class BlastAOE implements AOE {
         {
             for(Coord p : priorityTargets)
             {
-                ArrayList<Coord> ap = new ArrayList<Coord>();
+                ArrayList<Coord> ap = new ArrayList<>();
                 ap.add(p);
                 bestPoints.put(p, ap);
             }
@@ -398,7 +398,7 @@ public class BlastAOE implements AOE {
                 }
                 if(qualityMap[x][y] < bestQuality)
                 {
-                    ArrayList<Coord> ap = new ArrayList<Coord>();
+                    ArrayList<Coord> ap = new ArrayList<>();
 
                     for (int i = 0; i < pts.length && i < 63; ++i) {
                         if((pbits & (1 << i)) != 0)
@@ -415,7 +415,7 @@ public class BlastAOE implements AOE {
                     }
                 }
                 else if(qualityMap[x][y] == bestQuality) {
-                    ArrayList<Coord> ap = new ArrayList<Coord>();
+                    ArrayList<Coord> ap = new ArrayList<>();
 
                     for (int i = 0; i < pts.length && i < 63; ++i) {
                         if ((pbits & (1 << i)) != 0) {

--- a/squidlib-util/src/main/java/squidpony/squidai/BurstAOE.java
+++ b/squidlib-util/src/main/java/squidpony/squidai/BurstAOE.java
@@ -92,12 +92,12 @@ public class BurstAOE implements AOE {
     @Override
     public LinkedHashMap<Coord, ArrayList<Coord>> idealLocations(Set<Coord> targets, Set<Coord> requiredExclusions) {
         if(targets == null)
-            return new LinkedHashMap<Coord, ArrayList<Coord>>();
-        if(requiredExclusions == null) requiredExclusions = new LinkedHashSet<Coord>();
+            return new LinkedHashMap<>();
+        if(requiredExclusions == null) requiredExclusions = new LinkedHashSet<>();
 
         //requiredExclusions.remove(origin);
         int totalTargets = targets.size();
-        LinkedHashMap<Coord, ArrayList<Coord>> bestPoints = new LinkedHashMap<Coord, ArrayList<Coord>>(totalTargets * 8);
+        LinkedHashMap<Coord, ArrayList<Coord>> bestPoints = new LinkedHashMap<>(totalTargets * 8);
 
         if(totalTargets == 0)
             return bestPoints;
@@ -106,7 +106,7 @@ public class BurstAOE implements AOE {
         {
             for(Coord p : targets)
             {
-                ArrayList<Coord> ap = new ArrayList<Coord>();
+                ArrayList<Coord> ap = new ArrayList<>();
                 ap.add(p);
                 bestPoints.put(p, ap);
             }
@@ -197,7 +197,7 @@ public class BurstAOE implements AOE {
                 }
                 if(qualityMap[x][y] < bestQuality)
                 {
-                    ArrayList<Coord> ap = new ArrayList<Coord>();
+                    ArrayList<Coord> ap = new ArrayList<>();
 
                     for (int i = 0; i < ts.length && i < 63; ++i) {
                         if((bits & (1 << i)) != 0)
@@ -211,7 +211,7 @@ public class BurstAOE implements AOE {
                     }                }
                 else if(qualityMap[x][y] == bestQuality)
                 {
-                    ArrayList<Coord> ap = new ArrayList<Coord>();
+                    ArrayList<Coord> ap = new ArrayList<>();
 
                     for (int i = 0; i < ts.length && i < 63; ++i) {
                         if((bits & (1 << i)) != 0)
@@ -233,11 +233,11 @@ public class BurstAOE implements AOE {
     public LinkedHashMap<Coord, ArrayList<Coord>> idealLocations(Set<Coord> priorityTargets, Set<Coord> lesserTargets, Set<Coord> requiredExclusions) {
         if(priorityTargets == null)
             return idealLocations(lesserTargets, requiredExclusions);
-        if(requiredExclusions == null) requiredExclusions = new LinkedHashSet<Coord>();
+        if(requiredExclusions == null) requiredExclusions = new LinkedHashSet<>();
 
         //requiredExclusions.remove(origin);
         int totalTargets = priorityTargets.size() + lesserTargets.size();
-        LinkedHashMap<Coord, ArrayList<Coord>> bestPoints = new LinkedHashMap<Coord, ArrayList<Coord>>(totalTargets * 8);
+        LinkedHashMap<Coord, ArrayList<Coord>> bestPoints = new LinkedHashMap<>(totalTargets * 8);
 
         if(totalTargets == 0)
             return bestPoints;
@@ -246,7 +246,7 @@ public class BurstAOE implements AOE {
         {
             for(Coord p : priorityTargets)
             {
-                ArrayList<Coord> ap = new ArrayList<Coord>();
+                ArrayList<Coord> ap = new ArrayList<>();
                 ap.add(p);
                 bestPoints.put(p, ap);
             }
@@ -394,7 +394,7 @@ public class BurstAOE implements AOE {
                 }
                 if(qualityMap[x][y] < bestQuality)
                 {
-                    ArrayList<Coord> ap = new ArrayList<Coord>();
+                    ArrayList<Coord> ap = new ArrayList<>();
 
                     for (int i = 0; i < pts.length && i < 63; ++i) {
                         if((pbits & (1 << i)) != 0)
@@ -413,7 +413,7 @@ public class BurstAOE implements AOE {
                 }
                 else if(qualityMap[x][y] == bestQuality)
                 {
-                    ArrayList<Coord> ap = new ArrayList<Coord>();
+                    ArrayList<Coord> ap = new ArrayList<>();
 
                     for (int i = 0; i < pts.length && i < 63; ++i) {
                         if ((pbits & (1 << i)) != 0) {

--- a/squidlib-util/src/main/java/squidpony/squidai/CloudAOE.java
+++ b/squidlib-util/src/main/java/squidpony/squidai/CloudAOE.java
@@ -193,12 +193,12 @@ public class CloudAOE implements AOE {
     @Override
     public LinkedHashMap<Coord, ArrayList<Coord>> idealLocations(Set<Coord> targets, Set<Coord> requiredExclusions) {
         if(targets == null)
-            return new LinkedHashMap<Coord, ArrayList<Coord>>();
-        if(requiredExclusions == null) requiredExclusions = new LinkedHashSet<Coord>();
+            return new LinkedHashMap<>();
+        if(requiredExclusions == null) requiredExclusions = new LinkedHashSet<>();
 
         //requiredExclusions.remove(origin);
         int totalTargets = targets.size();
-        LinkedHashMap<Coord, ArrayList<Coord>> bestPoints = new LinkedHashMap<Coord, ArrayList<Coord>>(totalTargets * 8);
+        LinkedHashMap<Coord, ArrayList<Coord>> bestPoints = new LinkedHashMap<>(totalTargets * 8);
 
         if(totalTargets == 0 || volume <= 0)
             return bestPoints;
@@ -207,7 +207,7 @@ public class CloudAOE implements AOE {
         {
             for(Coord p : targets)
             {
-                ArrayList<Coord> ap = new ArrayList<Coord>();
+                ArrayList<Coord> ap = new ArrayList<>();
                 ap.add(p);
                 bestPoints.put(p, ap);
             }
@@ -301,7 +301,7 @@ public class CloudAOE implements AOE {
                 }
                 if(qualityMap[x][y] < bestQuality)
                 {
-                    ArrayList<Coord> ap = new ArrayList<Coord>();
+                    ArrayList<Coord> ap = new ArrayList<>();
 
                     for (int i = 0; i < ts.length && i < 63; ++i) {
                         if((bits & (1 << i)) != 0)
@@ -316,7 +316,7 @@ public class CloudAOE implements AOE {
                 }
                 else if(qualityMap[x][y] == bestQuality)
                 {
-                    ArrayList<Coord> ap = new ArrayList<Coord>();
+                    ArrayList<Coord> ap = new ArrayList<>();
 
                     for (int i = 0; i < ts.length && i < 63; ++i) {
                         if((bits & (1 << i)) != 0)
@@ -337,12 +337,12 @@ public class CloudAOE implements AOE {
     public LinkedHashMap<Coord, ArrayList<Coord>> idealLocations(Set<Coord> priorityTargets, Set<Coord> lesserTargets, Set<Coord> requiredExclusions) {
         if(priorityTargets == null)
             return idealLocations(lesserTargets, requiredExclusions);
-        if(requiredExclusions == null) requiredExclusions = new LinkedHashSet<Coord>();
+        if(requiredExclusions == null) requiredExclusions = new LinkedHashSet<>();
 
         //requiredExclusions.remove(origin);
 
         int totalTargets = priorityTargets.size() + lesserTargets.size();
-        LinkedHashMap<Coord, ArrayList<Coord>> bestPoints = new LinkedHashMap<Coord, ArrayList<Coord>>(totalTargets * 8);
+        LinkedHashMap<Coord, ArrayList<Coord>> bestPoints = new LinkedHashMap<>(totalTargets * 8);
 
         if(totalTargets == 0 || volume <= 0)
             return bestPoints;
@@ -351,7 +351,7 @@ public class CloudAOE implements AOE {
         {
             for(Coord p : priorityTargets)
             {
-                ArrayList<Coord> ap = new ArrayList<Coord>();
+                ArrayList<Coord> ap = new ArrayList<>();
                 ap.add(p);
                 bestPoints.put(p, ap);
             }
@@ -505,7 +505,7 @@ public class CloudAOE implements AOE {
                 }
                 if(qualityMap[x][y] < bestQuality)
                 {
-                    ArrayList<Coord> ap = new ArrayList<Coord>();
+                    ArrayList<Coord> ap = new ArrayList<>();
 
                     for (int i = 0; i < pts.length && i < 63; ++i) {
                         if((pbits & (1 << i)) != 0)
@@ -524,7 +524,7 @@ public class CloudAOE implements AOE {
                 }
                 else if(qualityMap[x][y] == bestQuality)
                 {
-                    ArrayList<Coord> ap = new ArrayList<Coord>();
+                    ArrayList<Coord> ap = new ArrayList<>();
 
                     for (int i = 0; i < pts.length && i < 63; ++i) {
                         if((pbits & (1 << i)) != 0)

--- a/squidlib-util/src/main/java/squidpony/squidai/ConeAOE.java
+++ b/squidlib-util/src/main/java/squidpony/squidai/ConeAOE.java
@@ -199,12 +199,12 @@ public class ConeAOE implements AOE {
     @Override
     public LinkedHashMap<Coord, ArrayList<Coord>> idealLocations(Set<Coord> targets, Set<Coord> requiredExclusions) {
         if(targets == null)
-            return new LinkedHashMap<Coord, ArrayList<Coord>>();
-        if(requiredExclusions == null) requiredExclusions = new LinkedHashSet<Coord>();
+            return new LinkedHashMap<>();
+        if(requiredExclusions == null) requiredExclusions = new LinkedHashSet<>();
 
         //requiredExclusions.remove(origin);
         int totalTargets = targets.size();
-        LinkedHashMap<Coord, ArrayList<Coord>> bestPoints = new LinkedHashMap<Coord, ArrayList<Coord>>(totalTargets * 8);
+        LinkedHashMap<Coord, ArrayList<Coord>> bestPoints = new LinkedHashMap<>(totalTargets * 8);
 
         if(totalTargets == 0)
             return bestPoints;
@@ -302,7 +302,7 @@ public class ConeAOE implements AOE {
                 }
                 if(qualityMap[x][y] < bestQuality)
                 {
-                    ArrayList<Coord> ap = new ArrayList<Coord>();
+                    ArrayList<Coord> ap = new ArrayList<>();
 
                     for (int i = 0; i < ts.length && i < 63; ++i) {
                         if((bits & (1 << i)) != 0)
@@ -315,7 +315,7 @@ public class ConeAOE implements AOE {
                     }
                 }
                 else if(qualityMap[x][y] == bestQuality) {
-                    ArrayList<Coord> ap = new ArrayList<Coord>();
+                    ArrayList<Coord> ap = new ArrayList<>();
 
                     for (int i = 0; i < ts.length && i < 63; ++i) {
                         if ((bits & (1 << i)) != 0)
@@ -336,11 +336,11 @@ public class ConeAOE implements AOE {
     public LinkedHashMap<Coord, ArrayList<Coord>> idealLocations(Set<Coord> priorityTargets, Set<Coord> lesserTargets, Set<Coord> requiredExclusions) {
         if(priorityTargets == null)
             return idealLocations(lesserTargets, requiredExclusions);
-        if(requiredExclusions == null) requiredExclusions = new LinkedHashSet<Coord>();
+        if(requiredExclusions == null) requiredExclusions = new LinkedHashSet<>();
 
         //requiredExclusions.remove(origin);
         int totalTargets = priorityTargets.size() + lesserTargets.size();
-        LinkedHashMap<Coord, ArrayList<Coord>> bestPoints = new LinkedHashMap<Coord, ArrayList<Coord>>(totalTargets * 8);
+        LinkedHashMap<Coord, ArrayList<Coord>> bestPoints = new LinkedHashMap<>(totalTargets * 8);
 
         if(totalTargets == 0)
             return bestPoints;
@@ -485,7 +485,7 @@ public class ConeAOE implements AOE {
                 }
                 if(qualityMap[x][y] < bestQuality)
                 {
-                    ArrayList<Coord> ap = new ArrayList<Coord>();
+                    ArrayList<Coord> ap = new ArrayList<>();
 
                     for (int i = 0; i < pts.length && i < 63; ++i) {
                         if((pbits & (1 << i)) != 0)
@@ -504,7 +504,7 @@ public class ConeAOE implements AOE {
 
                 }
                 else if(qualityMap[x][y] == bestQuality) {
-                    ArrayList<Coord> ap = new ArrayList<Coord>();
+                    ArrayList<Coord> ap = new ArrayList<>();
 
                     for (int i = 0; i < pts.length && i < 63; ++i) {
                         if ((pbits & (1 << i)) != 0) {

--- a/squidlib-util/src/main/java/squidpony/squidai/DijkstraMap.java
+++ b/squidlib-util/src/main/java/squidpony/squidai/DijkstraMap.java
@@ -86,7 +86,7 @@ public class DijkstraMap {
      * cell; only steps that require movement will be included, and so if the path has not been found or a valid
      * path toward a goal is impossible, this ArrayList will be empty.
      */
-    public ArrayList<Coord> path = new ArrayList<Coord>();
+    public ArrayList<Coord> path = new ArrayList<>();
     /**
      * Goals are always marked with 0.
      */
@@ -133,12 +133,12 @@ public class DijkstraMap {
      */
     public DijkstraMap() {
         rng = new RNG(new LightRNG());
-        path = new ArrayList<Coord>();
+        path = new ArrayList<>();
 
-        goals = new LinkedHashMap<Coord, Double>();
-        fresh = new LinkedHashMap<Coord, Double>();
-        closed = new LinkedHashMap<Coord, Double>();
-        open = new LinkedHashMap<Coord, Double>();
+        goals = new LinkedHashMap<>();
+        fresh = new LinkedHashMap<>();
+        closed = new LinkedHashMap<>();
+        open = new LinkedHashMap<>();
     }
 
     /**
@@ -148,12 +148,12 @@ public class DijkstraMap {
      */
     public DijkstraMap(RNG random) {
         rng = random;
-        path = new ArrayList<Coord>();
+        path = new ArrayList<>();
 
-        goals = new LinkedHashMap<Coord, Double>();
-        fresh = new LinkedHashMap<Coord, Double>();
-        closed = new LinkedHashMap<Coord, Double>();
-        open = new LinkedHashMap<Coord, Double>();
+        goals = new LinkedHashMap<>();
+        fresh = new LinkedHashMap<>();
+        closed = new LinkedHashMap<>();
+        open = new LinkedHashMap<>();
     }
 
     /**
@@ -163,12 +163,12 @@ public class DijkstraMap {
      */
     public DijkstraMap(final double[][] level) {
         rng = new RNG(new LightRNG());
-        path = new ArrayList<Coord>();
+        path = new ArrayList<>();
 
-        goals = new LinkedHashMap<Coord, Double>();
-        fresh = new LinkedHashMap<Coord, Double>();
-        closed = new LinkedHashMap<Coord, Double>();
-        open = new LinkedHashMap<Coord, Double>();
+        goals = new LinkedHashMap<>();
+        fresh = new LinkedHashMap<>();
+        closed = new LinkedHashMap<>();
+        open = new LinkedHashMap<>();
         initialize(level);
     }
 
@@ -181,12 +181,12 @@ public class DijkstraMap {
     public DijkstraMap(final double[][] level, Measurement measurement) {
         rng = new RNG(new LightRNG());
         this.measurement = measurement;
-        path = new ArrayList<Coord>();
+        path = new ArrayList<>();
 
-        goals = new LinkedHashMap<Coord, Double>();
-        fresh = new LinkedHashMap<Coord, Double>();
-        closed = new LinkedHashMap<Coord, Double>();
-        open = new LinkedHashMap<Coord, Double>();
+        goals = new LinkedHashMap<>();
+        fresh = new LinkedHashMap<>();
+        closed = new LinkedHashMap<>();
+        open = new LinkedHashMap<>();
         initialize(level);
     }
 
@@ -200,12 +200,12 @@ public class DijkstraMap {
      */
     public DijkstraMap(final char[][] level) {
         rng = new RNG(new LightRNG());
-        path = new ArrayList<Coord>();
+        path = new ArrayList<>();
 
-        goals = new LinkedHashMap<Coord, Double>();
-        fresh = new LinkedHashMap<Coord, Double>();
-        closed = new LinkedHashMap<Coord, Double>();
-        open = new LinkedHashMap<Coord, Double>();
+        goals = new LinkedHashMap<>();
+        fresh = new LinkedHashMap<>();
+        closed = new LinkedHashMap<>();
+        open = new LinkedHashMap<>();
         initialize(level);
     }
 
@@ -221,12 +221,12 @@ public class DijkstraMap {
      */
     public DijkstraMap(final char[][] level, RNG rng) {
         this.rng = rng;
-        path = new ArrayList<Coord>();
+        path = new ArrayList<>();
 
-        goals = new LinkedHashMap<Coord, Double>();
-        fresh = new LinkedHashMap<Coord, Double>();
-        closed = new LinkedHashMap<Coord, Double>();
-        open = new LinkedHashMap<Coord, Double>();
+        goals = new LinkedHashMap<>();
+        fresh = new LinkedHashMap<>();
+        closed = new LinkedHashMap<>();
+        open = new LinkedHashMap<>();
         initialize(level);
     }
 
@@ -240,12 +240,12 @@ public class DijkstraMap {
      */
     public DijkstraMap(final char[][] level, char alternateWall) {
         rng = new RNG(new LightRNG());
-        path = new ArrayList<Coord>();
+        path = new ArrayList<>();
 
-        goals = new LinkedHashMap<Coord, Double>();
-        fresh = new LinkedHashMap<Coord, Double>();
-        closed = new LinkedHashMap<Coord, Double>();
-        open = new LinkedHashMap<Coord, Double>();
+        goals = new LinkedHashMap<>();
+        fresh = new LinkedHashMap<>();
+        closed = new LinkedHashMap<>();
+        open = new LinkedHashMap<>();
         initialize(level, alternateWall);
     }
 
@@ -260,13 +260,13 @@ public class DijkstraMap {
      */
     public DijkstraMap(final char[][] level, Measurement measurement) {
         rng = new RNG(new LightRNG());
-        path = new ArrayList<Coord>();
+        path = new ArrayList<>();
         this.measurement = measurement;
 
-        goals = new LinkedHashMap<Coord, Double>();
-        fresh = new LinkedHashMap<Coord, Double>();
-        closed = new LinkedHashMap<Coord, Double>();
-        open = new LinkedHashMap<Coord, Double>();
+        goals = new LinkedHashMap<>();
+        fresh = new LinkedHashMap<>();
+        closed = new LinkedHashMap<>();
+        open = new LinkedHashMap<>();
         initialize(level);
     }
 
@@ -282,13 +282,13 @@ public class DijkstraMap {
      */
     public DijkstraMap(final char[][] level, Measurement measurement, RNG rng) {
         this.rng = rng;
-        path = new ArrayList<Coord>();
+        path = new ArrayList<>();
         this.measurement = measurement;
 
-        goals = new LinkedHashMap<Coord, Double>();
-        fresh = new LinkedHashMap<Coord, Double>();
-        closed = new LinkedHashMap<Coord, Double>();
-        open = new LinkedHashMap<Coord, Double>();
+        goals = new LinkedHashMap<>();
+        fresh = new LinkedHashMap<>();
+        closed = new LinkedHashMap<>();
+        open = new LinkedHashMap<>();
         initialize(level);
     }
 
@@ -737,8 +737,8 @@ public class DijkstraMap {
     public double[][] scan(Set<Coord> impassable) {
         if (!initialized) return null;
         if (impassable == null)
-            impassable = new LinkedHashSet<Coord>();
-        LinkedHashMap<Coord, Double> blocking = new LinkedHashMap<Coord, Double>(impassable.size());
+            impassable = new LinkedHashSet<>();
+        LinkedHashMap<Coord, Double> blocking = new LinkedHashMap<>(impassable.size());
         for (Coord pt : impassable) {
             blocking.put(pt, WALL);
         }
@@ -750,7 +750,7 @@ public class DijkstraMap {
             gradientMap[entry.getKey().x][entry.getKey().y] = entry.getValue();
         }
         double currentLowest = 999000;
-        LinkedHashMap<Coord, Double> lowest = new LinkedHashMap<Coord, Double>();
+        LinkedHashMap<Coord, Double> lowest = new LinkedHashMap<>();
 
         for (int y = 0; y < height; y++) {
             for (int x = 0; x < width; x++) {
@@ -785,7 +785,7 @@ public class DijkstraMap {
                 }
             }
 //            closed.putAll(open);
-            open = new LinkedHashMap<Coord, Double>(fresh);
+            open = new LinkedHashMap<>(fresh);
             fresh.clear();
         }
         closed.clear();
@@ -821,8 +821,8 @@ public class DijkstraMap {
     public double[][] partialScan(int limit, Set<Coord> impassable) {
         if (!initialized) return null;
         if (impassable == null)
-            impassable = new LinkedHashSet<Coord>();
-        LinkedHashMap<Coord, Double> blocking = new LinkedHashMap<Coord, Double>(impassable.size());
+            impassable = new LinkedHashSet<>();
+        LinkedHashMap<Coord, Double> blocking = new LinkedHashMap<>(impassable.size());
         for (Coord pt : impassable) {
             blocking.put(pt, WALL);
         }
@@ -834,7 +834,7 @@ public class DijkstraMap {
             gradientMap[entry.getKey().x][entry.getKey().y] = entry.getValue();
         }
         double currentLowest = 999000;
-        LinkedHashMap<Coord, Double> lowest = new LinkedHashMap<Coord, Double>();
+        LinkedHashMap<Coord, Double> lowest = new LinkedHashMap<>();
 
         for (int y = 0; y < height; y++) {
             for (int x = 0; x < width; x++) {
@@ -871,7 +871,7 @@ public class DijkstraMap {
                 }
             }
 //            closed.putAll(open);
-            open = new LinkedHashMap<Coord, Double>(fresh);
+            open = new LinkedHashMap<>(fresh);
             fresh.clear();
             ++iter;
         }
@@ -950,7 +950,7 @@ public class DijkstraMap {
                 }
             }
 //            closed.putAll(open);
-            open = new LinkedHashMap<Coord, Double>(fresh);
+            open = new LinkedHashMap<>(fresh);
             fresh.clear();
         }
         closed.clear();
@@ -967,7 +967,7 @@ public class DijkstraMap {
      * @return the Coord that it found first.
      */
     public Coord findNearest(Coord start, Coord... targets) {
-        LinkedHashSet<Coord> tgts = new LinkedHashSet<Coord>(targets.length);
+        LinkedHashSet<Coord> tgts = new LinkedHashSet<>(targets.length);
         Collections.addAll(tgts, targets);
         return findNearest(start, tgts);
     }
@@ -982,13 +982,13 @@ public class DijkstraMap {
      * @return an ArrayList of Coord that goes from a cell adjacent to start and goes to one of the targets.
      */
     public ArrayList<Coord> findShortcutPath(Coord start, Coord... targets) {
-        ArrayList<Coord> path = new ArrayList<Coord>(32);
+        ArrayList<Coord> path = new ArrayList<>(32);
         if (targets.length == 0)
             return path;
         Coord currentPos = findNearest(start, targets);
         while (true) {
             if (frustration > 500) {
-                path = new ArrayList<Coord>();
+                path = new ArrayList<>();
                 break;
             }
             double best = gradientMap[currentPos.x][currentPos.y];
@@ -1006,7 +1006,7 @@ public class DijkstraMap {
             }
 
             if (best >= gradientMap[currentPos.x][currentPos.y] || physicalMap[currentPos.x + dirs[choice].deltaX][currentPos.y + dirs[choice].deltaY] > FLOOR) {
-                path = new ArrayList<Coord>();
+                path = new ArrayList<>();
                 break;
             }
             currentPos = currentPos.translate(dirs[choice].deltaX, dirs[choice].deltaY);
@@ -1035,7 +1035,7 @@ public class DijkstraMap {
         if (!initialized) return null;
         if (targets == null)
             return null;
-        ArrayList<Coord> found = new ArrayList<Coord>(limit);
+        ArrayList<Coord> found = new ArrayList<>(limit);
         if (targets.contains(start))
             return found;
         Coord start2 = start;
@@ -1084,7 +1084,7 @@ public class DijkstraMap {
                 }
             }
 //            closed.putAll(open);
-            open = new LinkedHashMap<Coord, Double>(fresh);
+            open = new LinkedHashMap<>(fresh);
             fresh.clear();
         }
         closed.clear();
@@ -1115,8 +1115,8 @@ public class DijkstraMap {
     public double[][] scan(Set<Coord> impassable, int size) {
         if (!initialized) return null;
         if (impassable == null)
-            impassable = new LinkedHashSet<Coord>();
-        LinkedHashMap<Coord, Double> blocking = new LinkedHashMap<Coord, Double>(impassable.size());
+            impassable = new LinkedHashSet<>();
+        LinkedHashMap<Coord, Double> blocking = new LinkedHashMap<>(impassable.size());
         for (Coord pt : impassable) {
             blocking.put(pt, WALL);
             for (int x = 0; x < size; x++) {
@@ -1137,7 +1137,7 @@ public class DijkstraMap {
         }
         mappedCount = goals.size();
         double currentLowest = 999000;
-        LinkedHashMap<Coord, Double> lowest = new LinkedHashMap<Coord, Double>();
+        LinkedHashMap<Coord, Double> lowest = new LinkedHashMap<>();
         Coord p = Coord.get(0, 0), temp = Coord.get(0, 0);
         for (int y = 0; y < height; y++) {
             I_AM_BECOME_DEATH_DESTROYER_OF_WORLDS:
@@ -1206,7 +1206,7 @@ public class DijkstraMap {
                 }
             }
 //            closed.putAll(open);
-            open = new LinkedHashMap<Coord, Double>(fresh);
+            open = new LinkedHashMap<>(fresh);
             fresh.clear();
         }
         closed.clear();
@@ -1245,14 +1245,14 @@ public class DijkstraMap {
     public ArrayList<Coord> findPath(int length, Set<Coord> impassable,
                                      Set<Coord> onlyPassable, Coord start, Coord... targets) {
         if (!initialized) return null;
-        path = new ArrayList<Coord>();
+        path = new ArrayList<>();
         LinkedHashSet<Coord> impassable2;
         if (impassable == null)
-            impassable2 = new LinkedHashSet<Coord>();
+            impassable2 = new LinkedHashSet<>();
         else
-            impassable2 = new LinkedHashSet<Coord>(impassable);
+            impassable2 = new LinkedHashSet<>(impassable);
         if (onlyPassable == null)
-            onlyPassable = new LinkedHashSet<Coord>();
+            onlyPassable = new LinkedHashSet<>();
 
         resetMap();
         for (Coord goal : targets) {
@@ -1265,7 +1265,7 @@ public class DijkstraMap {
         double paidLength = 0.0;
         while (true) {
             if (frustration > 500) {
-                path = new ArrayList<Coord>();
+                path = new ArrayList<>();
                 break;
             }
             double best = gradientMap[currentPos.x][currentPos.y];
@@ -1283,7 +1283,7 @@ public class DijkstraMap {
             }
 
             if (best >= gradientMap[currentPos.x][currentPos.y] || physicalMap[currentPos.x + dirs[choice].deltaX][currentPos.y + dirs[choice].deltaY] > FLOOR) {
-                path = new ArrayList<Coord>();
+                path = new ArrayList<>();
                 break;
             }
             currentPos = currentPos.translate(dirs[choice].deltaX, dirs[choice].deltaY);
@@ -1369,14 +1369,14 @@ public class DijkstraMap {
                 }
             }
         }
-        path = new ArrayList<Coord>();
+        path = new ArrayList<>();
         LinkedHashSet<Coord> impassable2;
         if (impassable == null)
-            impassable2 = new LinkedHashSet<Coord>();
+            impassable2 = new LinkedHashSet<>();
         else
-            impassable2 = new LinkedHashSet<Coord>(impassable);
+            impassable2 = new LinkedHashSet<>(impassable);
         if (onlyPassable == null)
-            onlyPassable = new LinkedHashSet<Coord>();
+            onlyPassable = new LinkedHashSet<>();
 
         resetMap();
         for (Coord goal : targets) {
@@ -1418,7 +1418,7 @@ public class DijkstraMap {
         double paidLength = 0.0;
         while (true) {
             if (frustration > 500) {
-                path = new ArrayList<Coord>();
+                path = new ArrayList<>();
                 break;
             }
             double best = gradientMap[currentPos.x][currentPos.y];
@@ -1436,7 +1436,7 @@ public class DijkstraMap {
             }
 
             if (best >= gradientMap[currentPos.x][currentPos.y] || physicalMap[currentPos.x + dirs[choice].deltaX][currentPos.y + dirs[choice].deltaY] > FLOOR) {
-                path = new ArrayList<Coord>();
+                path = new ArrayList<>();
                 break;
             }
             currentPos = currentPos.translate(dirs[choice].deltaX, dirs[choice].deltaY);
@@ -1521,19 +1521,19 @@ public class DijkstraMap {
             }
         }
 
-        path = new ArrayList<Coord>();
+        path = new ArrayList<>();
         if (targets == null || targets.size() == 0)
             return path;
         LinkedHashSet<Coord> impassable2;
         if (impassable == null)
-            impassable2 = new LinkedHashSet<Coord>();
+            impassable2 = new LinkedHashSet<>();
         else
-            impassable2 = new LinkedHashSet<Coord>(impassable);
+            impassable2 = new LinkedHashSet<>(impassable);
 
         if (allies == null)
-            friends = new LinkedHashSet<Coord>();
+            friends = new LinkedHashSet<>();
         else {
-            friends = new LinkedHashSet<Coord>(allies);
+            friends = new LinkedHashSet<>(allies);
             friends.remove(start);
         }
 
@@ -1619,7 +1619,7 @@ public class DijkstraMap {
         Coord currentPos = Coord.get(start.x, start.y);
         while (true) {
             if (frustration > 500) {
-                path = new ArrayList<Coord>();
+                path = new ArrayList<>();
                 break;
             }
             double best = gradientMap[currentPos.x][currentPos.y];
@@ -1645,7 +1645,7 @@ public class DijkstraMap {
                 break;
             }
             if (best > gradientMap[start.x][start.y] || physicalMap[currentPos.x + dirs[choice].deltaX][currentPos.y + dirs[choice].deltaY] > FLOOR) {
-                path = new ArrayList<Coord>();
+                path = new ArrayList<>();
                 break;
             }
             currentPos = currentPos.translate(dirs[choice].deltaX, dirs[choice].deltaY);
@@ -1725,14 +1725,14 @@ public class DijkstraMap {
         if (minPreferredRange < 0) minPreferredRange = 0;
         if (maxPreferredRange < minPreferredRange) maxPreferredRange = minPreferredRange;
 
-        path = new ArrayList<Coord>();
+        path = new ArrayList<>();
         LinkedHashSet<Coord> impassable2;
         if (impassable == null)
-            impassable2 = new LinkedHashSet<Coord>();
+            impassable2 = new LinkedHashSet<>();
         else
-            impassable2 = new LinkedHashSet<Coord>(impassable);
+            impassable2 = new LinkedHashSet<>(impassable);
         if (onlyPassable == null)
-            onlyPassable = new LinkedHashSet<Coord>();
+            onlyPassable = new LinkedHashSet<>();
 
         resetMap();
         for (Coord goal : targets) {
@@ -1774,7 +1774,7 @@ public class DijkstraMap {
         double paidLength = 0.0;
         while (true) {
             if (frustration > 500) {
-                path = new ArrayList<Coord>();
+                path = new ArrayList<>();
                 break;
             }
             double best = gradientMap[currentPos.x][currentPos.y];
@@ -1792,7 +1792,7 @@ public class DijkstraMap {
             }
 
             if (best >= gradientMap[currentPos.x][currentPos.y] || physicalMap[currentPos.x + dirs[choice].deltaX][currentPos.y + dirs[choice].deltaY] > FLOOR) {
-                path = new ArrayList<Coord>();
+                path = new ArrayList<>();
                 break;
             }
             currentPos = currentPos.translate(dirs[choice].deltaX, dirs[choice].deltaY);
@@ -1903,14 +1903,14 @@ public class DijkstraMap {
             }
         }
 
-        path = new ArrayList<Coord>();
+        path = new ArrayList<>();
         LinkedHashSet<Coord> impassable2;
         if (impassable == null)
-            impassable2 = new LinkedHashSet<Coord>();
+            impassable2 = new LinkedHashSet<>();
         else
-            impassable2 = new LinkedHashSet<Coord>(impassable);
+            impassable2 = new LinkedHashSet<>(impassable);
         if (onlyPassable == null)
-            onlyPassable = new LinkedHashSet<Coord>();
+            onlyPassable = new LinkedHashSet<>();
 
         resetMap();
         for (Coord goal : targets) {
@@ -1925,7 +1925,7 @@ public class DijkstraMap {
         }
         scan(impassable2);
         goals.clear();
-        LinkedHashMap<Coord, Double> cachedGoals = new LinkedHashMap<Coord, Double>();
+        LinkedHashMap<Coord, Double> cachedGoals = new LinkedHashMap<>();
 
         for (int x = 0; x < width; x++) {
             CELL:
@@ -2000,7 +2000,7 @@ public class DijkstraMap {
         double paidLength = 0.0;
         while (true) {
             if (frustration > 500) {
-                path = new ArrayList<Coord>();
+                path = new ArrayList<>();
                 break;
             }
             double best = gradientMap[currentPos.x][currentPos.y];
@@ -2103,19 +2103,19 @@ public class DijkstraMap {
             }
         }
 
-        path = new ArrayList<Coord>();
+        path = new ArrayList<>();
         if (targets == null || targets.size() == 0)
             return path;
         LinkedHashSet<Coord> impassable2;
         if (impassable == null)
-            impassable2 = new LinkedHashSet<Coord>();
+            impassable2 = new LinkedHashSet<>();
         else
-            impassable2 = new LinkedHashSet<Coord>(impassable);
+            impassable2 = new LinkedHashSet<>(impassable);
 
         if (allies == null)
-            friends = new LinkedHashSet<Coord>();
+            friends = new LinkedHashSet<>();
         else {
-            friends = new LinkedHashSet<Coord>(allies);
+            friends = new LinkedHashSet<>(allies);
             friends.remove(start);
         }
 
@@ -2201,7 +2201,7 @@ public class DijkstraMap {
         Coord currentPos = Coord.get(start.x, start.y);
         while (true) {
             if (frustration > 500) {
-                path = new ArrayList<Coord>();
+                path = new ArrayList<>();
                 break;
             }
             double best = gradientMap[currentPos.x][currentPos.y];
@@ -2227,7 +2227,7 @@ public class DijkstraMap {
                 break;
             }
             if (best > gradientMap[start.x][start.y] || physicalMap[currentPos.x + dirs[choice].deltaX][currentPos.y + dirs[choice].deltaY] > FLOOR) {
-                path = new ArrayList<Coord>();
+                path = new ArrayList<>();
                 break;
             }
             currentPos = currentPos.translate(dirs[choice].deltaX, dirs[choice].deltaY);
@@ -2253,7 +2253,7 @@ public class DijkstraMap {
 
 
     private double cachedLongerPaths = 1.2;
-    private Set<Coord> cachedImpassable = new LinkedHashSet<Coord>();
+    private Set<Coord> cachedImpassable = new LinkedHashSet<>();
     private Coord[] cachedFearSources;
     private double[][] cachedFleeMap;
     private int cachedSize = 1;
@@ -2284,17 +2284,17 @@ public class DijkstraMap {
     public ArrayList<Coord> findFleePath(int length, double preferLongerPaths, Set<Coord> impassable,
                                          Set<Coord> onlyPassable, Coord start, Coord... fearSources) {
         if (!initialized) return null;
-        path = new ArrayList<Coord>();
+        path = new ArrayList<>();
         LinkedHashSet<Coord> impassable2;
         if (impassable == null)
-            impassable2 = new LinkedHashSet<Coord>();
+            impassable2 = new LinkedHashSet<>();
         else
-            impassable2 = new LinkedHashSet<Coord>(impassable);
+            impassable2 = new LinkedHashSet<>(impassable);
 
         if (onlyPassable == null)
-            onlyPassable = new LinkedHashSet<Coord>();
+            onlyPassable = new LinkedHashSet<>();
         if (fearSources == null || fearSources.length < 1) {
-            path = new ArrayList<Coord>();
+            path = new ArrayList<>();
             return path;
         }
         if (cachedSize == 1 && preferLongerPaths == cachedLongerPaths && impassable2.equals(cachedImpassable) &&
@@ -2302,7 +2302,7 @@ public class DijkstraMap {
             gradientMap = cachedFleeMap;
         } else {
             cachedLongerPaths = preferLongerPaths;
-            cachedImpassable = new LinkedHashSet<Coord>(impassable2);
+            cachedImpassable = new LinkedHashSet<>(impassable2);
             cachedFearSources = GwtCompatibility.cloneCoords(fearSources);
             cachedSize = 1;
             resetMap();
@@ -2325,7 +2325,7 @@ public class DijkstraMap {
         double paidLength = 0.0;
         while (true) {
             if (frustration > 500) {
-                path = new ArrayList<Coord>();
+                path = new ArrayList<>();
                 break;
             }
             double best = gradientMap[currentPos.x][currentPos.y];
@@ -2342,7 +2342,7 @@ public class DijkstraMap {
                 }
             }
             if (best >= gradientMap[start.x][start.y] || physicalMap[currentPos.x + dirs[choice].deltaX][currentPos.y + dirs[choice].deltaY] > FLOOR) {
-                path = new ArrayList<Coord>();
+                path = new ArrayList<>();
                 break;
             }
             currentPos = currentPos.translate(dirs[choice].deltaX, dirs[choice].deltaY);
@@ -2394,15 +2394,15 @@ public class DijkstraMap {
     public ArrayList<Coord> findPathLarge(int size, int length, Set<Coord> impassable,
                                           Set<Coord> onlyPassable, Coord start, Coord... targets) {
         if (!initialized) return null;
-        path = new ArrayList<Coord>();
+        path = new ArrayList<>();
         LinkedHashSet<Coord> impassable2;
         if (impassable == null)
-            impassable2 = new LinkedHashSet<Coord>();
+            impassable2 = new LinkedHashSet<>();
         else
-            impassable2 = new LinkedHashSet<Coord>(impassable);
+            impassable2 = new LinkedHashSet<>(impassable);
 
         if (onlyPassable == null)
-            onlyPassable = new LinkedHashSet<Coord>();
+            onlyPassable = new LinkedHashSet<>();
 
         resetMap();
         for (Coord goal : targets) {
@@ -2416,7 +2416,7 @@ public class DijkstraMap {
         double paidLength = 0.0;
         while (true) {
             if (frustration > 500) {
-                path = new ArrayList<Coord>();
+                path = new ArrayList<>();
                 break;
             }
             double best = gradientMap[currentPos.x][currentPos.y];
@@ -2434,7 +2434,7 @@ public class DijkstraMap {
             }
 
             if (best >= gradientMap[currentPos.x][currentPos.y] || physicalMap[currentPos.x + dirs[choice].deltaX][currentPos.y + dirs[choice].deltaY] > FLOOR) {
-                path = new ArrayList<Coord>();
+                path = new ArrayList<>();
                 break;
             }
             currentPos = currentPos.translate(dirs[choice].deltaX, dirs[choice].deltaY);
@@ -2496,15 +2496,15 @@ public class DijkstraMap {
                 }
             }
         }
-        path = new ArrayList<Coord>();
+        path = new ArrayList<>();
         LinkedHashSet<Coord> impassable2;
         if (impassable == null)
-            impassable2 = new LinkedHashSet<Coord>();
+            impassable2 = new LinkedHashSet<>();
         else
-            impassable2 = new LinkedHashSet<Coord>(impassable);
+            impassable2 = new LinkedHashSet<>(impassable);
 
         if (onlyPassable == null)
-            onlyPassable = new LinkedHashSet<Coord>();
+            onlyPassable = new LinkedHashSet<>();
 
         resetMap();
         for (Coord goal : targets) {
@@ -2549,7 +2549,7 @@ public class DijkstraMap {
         double paidLength = 0.0;
         while (true) {
             if (frustration > 500) {
-                path = new ArrayList<Coord>();
+                path = new ArrayList<>();
                 break;
             }
             double best = gradientMap[currentPos.x][currentPos.y];
@@ -2567,7 +2567,7 @@ public class DijkstraMap {
             }
 
             if (best >= gradientMap[currentPos.x][currentPos.y] || physicalMap[currentPos.x + dirs[choice].deltaX][currentPos.y + dirs[choice].deltaY] > FLOOR) {
-                path = new ArrayList<Coord>();
+                path = new ArrayList<>();
                 break;
             }
             currentPos = currentPos.translate(dirs[choice].deltaX, dirs[choice].deltaY);
@@ -2631,15 +2631,15 @@ public class DijkstraMap {
                 }
             }
         }
-        path = new ArrayList<Coord>();
+        path = new ArrayList<>();
         LinkedHashSet<Coord> impassable2;
         if (impassable == null)
-            impassable2 = new LinkedHashSet<Coord>();
+            impassable2 = new LinkedHashSet<>();
         else
-            impassable2 = new LinkedHashSet<Coord>(impassable);
+            impassable2 = new LinkedHashSet<>(impassable);
 
         if (onlyPassable == null)
-            onlyPassable = new LinkedHashSet<Coord>();
+            onlyPassable = new LinkedHashSet<>();
 
         resetMap();
         for (Coord goal : targets) {
@@ -2684,7 +2684,7 @@ public class DijkstraMap {
         double paidLength = 0.0;
         while (true) {
             if (frustration > 500) {
-                path = new ArrayList<Coord>();
+                path = new ArrayList<>();
                 break;
             }
 
@@ -2702,7 +2702,7 @@ public class DijkstraMap {
                 }
             }
             if (best >= gradientMap[currentPos.x][currentPos.y] || physicalMap[currentPos.x + dirs[choice].deltaX][currentPos.y + dirs[choice].deltaY] > FLOOR) {
-                path = new ArrayList<Coord>();
+                path = new ArrayList<>();
                 break;
             }
             currentPos = currentPos.translate(dirs[choice].deltaX, dirs[choice].deltaY);
@@ -2758,17 +2758,17 @@ public class DijkstraMap {
     public ArrayList<Coord> findFleePathLarge(int size, int length, double preferLongerPaths, Set<Coord> impassable,
                                               Set<Coord> onlyPassable, Coord start, Coord... fearSources) {
         if (!initialized) return null;
-        path = new ArrayList<Coord>();
+        path = new ArrayList<>();
         LinkedHashSet<Coord> impassable2;
         if (impassable == null)
-            impassable2 = new LinkedHashSet<Coord>();
+            impassable2 = new LinkedHashSet<>();
         else
-            impassable2 = new LinkedHashSet<Coord>(impassable);
+            impassable2 = new LinkedHashSet<>(impassable);
 
         if (onlyPassable == null)
-            onlyPassable = new LinkedHashSet<Coord>();
+            onlyPassable = new LinkedHashSet<>();
         if (fearSources == null || fearSources.length < 1) {
-            path = new ArrayList<Coord>();
+            path = new ArrayList<>();
             return path;
         }
         if (size == cachedSize && preferLongerPaths == cachedLongerPaths && impassable2.equals(cachedImpassable)
@@ -2776,7 +2776,7 @@ public class DijkstraMap {
             gradientMap = cachedFleeMap;
         } else {
             cachedLongerPaths = preferLongerPaths;
-            cachedImpassable = new LinkedHashSet<Coord>(impassable2);
+            cachedImpassable = new LinkedHashSet<>(impassable2);
             cachedFearSources = GwtCompatibility.cloneCoords(fearSources);
             cachedSize = size;
             resetMap();
@@ -2799,7 +2799,7 @@ public class DijkstraMap {
         double paidLength = 0.0;
         while (true) {
             if (frustration > 500) {
-                path = new ArrayList<Coord>();
+                path = new ArrayList<>();
                 break;
             }
 
@@ -2817,7 +2817,7 @@ public class DijkstraMap {
                 }
             }
             if (best >= gradientMap[currentPos.x][currentPos.y] || physicalMap[currentPos.x + dirs[choice].deltaX][currentPos.y + dirs[choice].deltaY] > FLOOR) {
-                path = new ArrayList<Coord>();
+                path = new ArrayList<>();
                 break;
             }
             currentPos = currentPos.translate(dirs[choice].deltaX, dirs[choice].deltaY);
@@ -2856,11 +2856,11 @@ public class DijkstraMap {
     public ArrayList<Coord> findPathPreScanned(Coord target) {
         if (!initialized || goals == null || goals.isEmpty()) return null;
         RNG rng2 = new StatefulRNG(new LightRNG(0xf00d));
-        path = new ArrayList<Coord>();
+        path = new ArrayList<>();
         Coord currentPos = target;
         while (true) {
             if (frustration > 2000) {
-                path = new ArrayList<Coord>();
+                path = new ArrayList<>();
                 break;
             }
             double best = gradientMap[currentPos.x][currentPos.y];
@@ -2878,7 +2878,7 @@ public class DijkstraMap {
             }
 
             if (best >= gradientMap[currentPos.x][currentPos.y] || physicalMap[currentPos.x + dirs[choice].deltaX][currentPos.y + dirs[choice].deltaY] > FLOOR) {
-                path = new ArrayList<Coord>();
+                path = new ArrayList<>();
                 break;
             }
             currentPos = currentPos.translate(dirs[choice].deltaX, dirs[choice].deltaY);
@@ -2903,7 +2903,7 @@ public class DijkstraMap {
      */
     public LinkedHashMap<Coord, Double> floodFill(int radius, Coord... starts) {
         if (!initialized) return null;
-        LinkedHashMap<Coord, Double> fill = new LinkedHashMap<Coord, Double>();
+        LinkedHashMap<Coord, Double> fill = new LinkedHashMap<>();
 
         resetMap();
         for (Coord goal : starts) {

--- a/squidlib-util/src/main/java/squidpony/squidai/LineAOE.java
+++ b/squidlib-util/src/main/java/squidpony/squidai/LineAOE.java
@@ -261,12 +261,12 @@ public class LineAOE implements AOE {
     @Override
     public LinkedHashMap<Coord, ArrayList<Coord>> idealLocations(Set<Coord> targets, Set<Coord> requiredExclusions) {
         if(targets == null)
-            return new LinkedHashMap<Coord, ArrayList<Coord>>();
-        if(requiredExclusions == null) requiredExclusions = new LinkedHashSet<Coord>();
+            return new LinkedHashMap<>();
+        if(requiredExclusions == null) requiredExclusions = new LinkedHashSet<>();
 
         //requiredExclusions.remove(origin);
         int totalTargets = targets.size();
-        LinkedHashMap<Coord, ArrayList<Coord>> bestPoints = new LinkedHashMap<Coord, ArrayList<Coord>>(totalTargets * 8);
+        LinkedHashMap<Coord, ArrayList<Coord>> bestPoints = new LinkedHashMap<>(totalTargets * 8);
 
         if(totalTargets == 0)
             return bestPoints;
@@ -372,7 +372,7 @@ public class LineAOE implements AOE {
                 }
                 if(qualityMap[x][y] < bestQuality)
                 {
-                    ArrayList<Coord> ap = new ArrayList<Coord>();
+                    ArrayList<Coord> ap = new ArrayList<>();
 
                     for (int i = 0; i < ts.length && i < 63; ++i) {
                         if((bits & (1 << i)) != 0)
@@ -386,7 +386,7 @@ public class LineAOE implements AOE {
                 }
                 else if(qualityMap[x][y] == bestQuality)
                 {
-                    ArrayList<Coord> ap = new ArrayList<Coord>();
+                    ArrayList<Coord> ap = new ArrayList<>();
 
                     for (int i = 0; i < ts.length && i < 63; ++i) {
                         if((bits & (1 << i)) != 0)
@@ -407,11 +407,11 @@ public class LineAOE implements AOE {
     public LinkedHashMap<Coord, ArrayList<Coord>> idealLocations(Set<Coord> priorityTargets, Set<Coord> lesserTargets, Set<Coord> requiredExclusions) {
         if(priorityTargets == null)
             return idealLocations(lesserTargets, requiredExclusions);
-        if(requiredExclusions == null) requiredExclusions = new LinkedHashSet<Coord>();
+        if(requiredExclusions == null) requiredExclusions = new LinkedHashSet<>();
 
         //requiredExclusions.remove(origin);
         int totalTargets = priorityTargets.size() + lesserTargets.size();
-        LinkedHashMap<Coord, ArrayList<Coord>> bestPoints = new LinkedHashMap<Coord, ArrayList<Coord>>(totalTargets * 8);
+        LinkedHashMap<Coord, ArrayList<Coord>> bestPoints = new LinkedHashMap<>(totalTargets * 8);
 
         if(totalTargets == 0)
             return bestPoints;
@@ -577,7 +577,7 @@ public class LineAOE implements AOE {
                 }
                 if(qualityMap[x][y] < bestQuality)
                 {
-                    ArrayList<Coord> ap = new ArrayList<Coord>();
+                    ArrayList<Coord> ap = new ArrayList<>();
 
                     for (int i = 0; i < pts.length && i < 63; ++i) {
                         if((pbits & (1 << i)) != 0)
@@ -595,7 +595,7 @@ public class LineAOE implements AOE {
                     }
                 }
                 else if(qualityMap[x][y] == bestQuality) {
-                    ArrayList<Coord> ap = new ArrayList<Coord>();
+                    ArrayList<Coord> ap = new ArrayList<>();
 
                     for (int i = 0; i < pts.length && i < 63; ++i) {
                         if ((pbits & (1 << i)) != 0) {

--- a/squidlib-util/src/main/java/squidpony/squidai/PointAOE.java
+++ b/squidlib-util/src/main/java/squidpony/squidai/PointAOE.java
@@ -66,10 +66,10 @@ public class PointAOE implements AOE {
     @Override
     public LinkedHashMap<Coord, ArrayList<Coord>> idealLocations(Set<Coord> targets, Set<Coord> requiredExclusions) {
         if(targets == null)
-            return new LinkedHashMap<Coord, ArrayList<Coord>>();
+            return new LinkedHashMap<>();
 
         int totalTargets = targets.size();
-        LinkedHashMap<Coord, ArrayList<Coord>> bestPoints = new LinkedHashMap<Coord, ArrayList<Coord>>(totalTargets);
+        LinkedHashMap<Coord, ArrayList<Coord>> bestPoints = new LinkedHashMap<>(totalTargets);
 
         if(totalTargets == 0)
             return bestPoints;
@@ -81,7 +81,7 @@ public class PointAOE implements AOE {
 
                 dist = reach.metric.radius(origin.x, origin.y, p.x, p.y);
                 if (dist <= reach.maxDistance && dist >= reach.minDistance) {
-                    ArrayList<Coord> ap = new ArrayList<Coord>();
+                    ArrayList<Coord> ap = new ArrayList<>();
                     ap.add(p);
                     bestPoints.put(p, ap);
                 }
@@ -95,10 +95,10 @@ public class PointAOE implements AOE {
     public LinkedHashMap<Coord, ArrayList<Coord>> idealLocations(Set<Coord> priorityTargets, Set<Coord> lesserTargets, Set<Coord> requiredExclusions) {
         if(priorityTargets == null)
             return idealLocations(lesserTargets, requiredExclusions);
-        if(requiredExclusions == null) requiredExclusions = new LinkedHashSet<Coord>();
+        if(requiredExclusions == null) requiredExclusions = new LinkedHashSet<>();
 
         int totalTargets = priorityTargets.size() + lesserTargets.size();
-        LinkedHashMap<Coord, ArrayList<Coord>> bestPoints = new LinkedHashMap<Coord, ArrayList<Coord>>(totalTargets * 4);
+        LinkedHashMap<Coord, ArrayList<Coord>> bestPoints = new LinkedHashMap<>(totalTargets * 4);
 
         if(totalTargets == 0)
             return bestPoints;
@@ -110,7 +110,7 @@ public class PointAOE implements AOE {
 
                 dist = reach.metric.radius(origin.x, origin.y, p.x, p.y);
                 if (dist <= reach.maxDistance && dist >= reach.minDistance) {
-                    ArrayList<Coord> ap = new ArrayList<Coord>();
+                    ArrayList<Coord> ap = new ArrayList<>();
                     ap.add(p);
                     ap.add(p);
                     ap.add(p);
@@ -125,7 +125,7 @@ public class PointAOE implements AOE {
 
                     dist = reach.metric.radius(origin.x, origin.y, p.x, p.y);
                     if (dist <= reach.maxDistance && dist >= reach.minDistance) {
-                        ArrayList<Coord> ap = new ArrayList<Coord>();
+                        ArrayList<Coord> ap = new ArrayList<>();
                         ap.add(p);
                         bestPoints.put(p, ap);
                     }
@@ -223,7 +223,7 @@ public class PointAOE implements AOE {
 
     @Override
     public LinkedHashMap<Coord, Double> findArea() {
-        LinkedHashMap<Coord, Double> ret = new LinkedHashMap<Coord, Double>(1);
+        LinkedHashMap<Coord, Double> ret = new LinkedHashMap<>(1);
         ret.put(Coord.get(center.x, center.y), 1.0);
         return ret;
     }

--- a/squidlib-util/src/main/java/squidpony/squidai/WaypointPathfinder.java
+++ b/squidlib-util/src/main/java/squidpony/squidai/WaypointPathfinder.java
@@ -48,7 +48,7 @@ public class WaypointPathfinder {
                 Math.min(width, height) * 0.4f, this.rng, '#');
         int centerCount = centers.size();
         expansionMap = new int[width][height];
-        waypoints = new LinkedHashMap<Coord, LinkedHashMap<Coord, Edge>>(64);
+        waypoints = new LinkedHashMap<>(64);
         dm = new DijkstraMap(simplified, DijkstraMap.Measurement.MANHATTAN);
 
         for (Coord center : centers) {
@@ -79,7 +79,7 @@ public class WaypointPathfinder {
             }
         }
 
-        LinkedHashSet<Coord> chokes = new LinkedHashSet<Coord>(128);
+        LinkedHashSet<Coord> chokes = new LinkedHashSet<>(128);
         for (int i = 0; i < width; i++) {
             ELEMENT_WISE:
             for (int j = 0; j < height; j++) {
@@ -171,8 +171,8 @@ public class WaypointPathfinder {
         height = map[0].length;
         char[][] simplified = DungeonUtility.simplifyDungeon(map);
         expansionMap = new int[width][height];
-        waypoints = new LinkedHashMap<Coord, LinkedHashMap<Coord, Edge>>(64);
-        LinkedHashSet<Coord> chokes = new LinkedHashSet<Coord>(128);
+        waypoints = new LinkedHashMap<>(64);
+        LinkedHashSet<Coord> chokes = new LinkedHashSet<>(128);
 
         if(thickCorridors)
         {
@@ -292,8 +292,8 @@ public class WaypointPathfinder {
         height = map[0].length;
         char[][] simplified = DungeonUtility.simplifyDungeon(map);
         expansionMap = new int[width][height];
-        waypoints = new LinkedHashMap<Coord, LinkedHashMap<Coord, Edge>>(64);
-        LinkedHashSet<Coord> chokes = new LinkedHashSet<Coord>(128);
+        waypoints = new LinkedHashMap<>(64);
+        LinkedHashSet<Coord> chokes = new LinkedHashSet<>(128);
 
         short[] floors = pack(simplified, '.');
         Coord[] apart = fractionPacked(floors, fraction);
@@ -345,7 +345,7 @@ public class WaypointPathfinder {
                 Math.min(width, height) * 0.4f, this.rng, '#');
         int centerCount = centers.size();
         expansionMap = new int[width][height];
-        waypoints = new LinkedHashMap<Coord, LinkedHashMap<Coord, Edge>>(64);
+        waypoints = new LinkedHashMap<>(64);
         dm = new DijkstraMap(simplified, DijkstraMap.Measurement.MANHATTAN);
 
         for (Coord center : centers) {
@@ -376,7 +376,7 @@ public class WaypointPathfinder {
             }
         }
 
-        LinkedHashSet<Coord> chokes = new LinkedHashSet<Coord>(128);
+        LinkedHashSet<Coord> chokes = new LinkedHashSet<>(128);
         for (int i = 0; i < width; i++) {
             ELEMENT_WISE:
             for (int j = 0; j < height; j++) {
@@ -433,7 +433,7 @@ public class WaypointPathfinder {
         ArrayList<Coord> near = dm.findNearestMultiple(approximateTarget, 5, waypoints.keySet());
         Coord me = dm.findNearest(self, waypoints.keySet());
         double bestCost = 999999.0;
-        ArrayList<Coord> path = new ArrayList<Coord>();
+        ArrayList<Coord> path = new ArrayList<>();
         /*if (waypoints.containsKey(me)) {
             Edge[] ed = waypoints.get(me).values().toArray(new Edge[waypoints.get(me).size()]);
             Arrays.sort(ed);
@@ -453,7 +453,7 @@ public class WaypointPathfinder {
                     continue;
                 if (ed.cost < bestCost) {
                     bestCost = ed.cost;
-                    path = new ArrayList<Coord>(ed.path);
+                    path = new ArrayList<>(ed.path);
                 }
             }
         }
@@ -486,7 +486,7 @@ public class WaypointPathfinder {
 
     public LinkedHashSet<Coord> getWaypoints()
     {
-        return new LinkedHashSet<Coord>(waypoints.keySet());
+        return new LinkedHashSet<>(waypoints.keySet());
     }
 
     private static class Edge implements Comparable<Edge>

--- a/squidlib-util/src/main/java/squidpony/squidgrid/FOVCache.java
+++ b/squidlib-util/src/main/java/squidpony/squidgrid/FOVCache.java
@@ -141,7 +141,7 @@ public class FOVCache extends FOV{
         decay = 1.0 / maxRadius;
         this.radiusKind = radiusKind;
         fovPermissiveness = 0.9;
-        lights = new LinkedHashMap<Coord, Integer>();
+        lights = new LinkedHashMap<>();
         cache = new short[mapLimit][][];
         tmpCache = new short[mapLimit][][];
         losCache = new short[mapLimit][];
@@ -210,7 +210,7 @@ public class FOVCache extends FOV{
         decay = 1.0 / maxRadius;
         this.radiusKind = radiusKind;
         fovPermissiveness = 0.9;
-        lights = new LinkedHashMap<Coord, Integer>();
+        lights = new LinkedHashMap<>();
         cache = new short[mapLimit][][];
         tmpCache = new short[mapLimit][][];
         losCache = new short[mapLimit][];
@@ -282,7 +282,7 @@ public class FOVCache extends FOV{
         decay = 1.0 / maxRadius;
         this.radiusKind = radiusKind;
         fovPermissiveness = 0.9;
-        this.lights = new LinkedHashMap<Coord, Integer>(lights);
+        this.lights = new LinkedHashMap<>(lights);
         cache = new short[mapLimit][][];
         tmpCache = new short[mapLimit][][];
         losCache = new short[mapLimit][];
@@ -1617,7 +1617,7 @@ public class FOVCache extends FOV{
         if(!complete || startX < 0 || startX >= width || startY < 0 || startY >= height)
             return new Coord[0];
         int max = distance(endX - startX, endY - startY);
-        ArrayList<Coord> path = new ArrayList<Coord>(max / 2 + 1);
+        ArrayList<Coord> path = new ArrayList<>(max / 2 + 1);
         short[] losCached = losCache[startX + startY * width];
         if(losCached.length == 0)
             return new Coord[0];
@@ -1673,7 +1673,7 @@ public class FOVCache extends FOV{
      */
     public Coord[] sortedLOS(int startX, int startY, int endX, int endY) {
         Coord[] path = calculateLOS(startX, startY, endX, endY);
-        SortedMap<Double, Coord> sorted = new TreeMap<Double, Coord>();
+        SortedMap<Double, Coord> sorted = new TreeMap<>();
         double modifier = 0.0001;
         Coord c;
         for (int i = 0; i < path.length; i++, modifier += 0.0001) {
@@ -1844,8 +1844,8 @@ public class FOVCache extends FOV{
          */
         @Override
         public void run() {
-            ArrayList<ArrayList<LOSUnit>> losUnits = new ArrayList<ArrayList<LOSUnit>>(24);
-            ArrayList<ArrayList<FOVUnit>> fovUnits = new ArrayList<ArrayList<FOVUnit>>(24);
+            ArrayList<ArrayList<LOSUnit>> losUnits = new ArrayList<>(24);
+            ArrayList<ArrayList<FOVUnit>> fovUnits = new ArrayList<>(24);
             for (int p = 0; p < 24; p++) {
                 losUnits.add(new ArrayList<LOSUnit>(mapLimit / 20));
                 fovUnits.add(new ArrayList<FOVUnit>(mapLimit / 20));
@@ -1933,7 +1933,7 @@ public class FOVCache extends FOV{
                 }
             }
 
-            ArrayList<ArrayList<SymmetryUnit>> symUnits = new ArrayList<ArrayList<SymmetryUnit>>(4);
+            ArrayList<ArrayList<SymmetryUnit>> symUnits = new ArrayList<>(4);
             for (int p = 0; p < 4; p++) {
                 symUnits.add(new ArrayList<SymmetryUnit>(mapLimit / 3));
             }
@@ -2017,9 +2017,9 @@ public class FOVCache extends FOV{
             needsChange = differencePacked(needsChange, wallMap);
             resMap = res;
             Coord[] changingCoords = allPacked(needsChange);
-            List<LOSUnit> losUnits = new ArrayList<LOSUnit>(changingCoords.length);
-            List<FOVUnit> fovUnits = new ArrayList<FOVUnit>(changingCoords.length);
-            List<SymmetryUnit> symUnits = new ArrayList<SymmetryUnit>(changingCoords.length);
+            List<LOSUnit> losUnits = new ArrayList<>(changingCoords.length);
+            List<FOVUnit> fovUnits = new ArrayList<>(changingCoords.length);
+            List<SymmetryUnit> symUnits = new ArrayList<>(changingCoords.length);
 
             for (int i = 0, idx; i < changingCoords.length; i++)
             {

--- a/squidlib-util/src/main/java/squidpony/squidgrid/LOS.java
+++ b/squidlib-util/src/main/java/squidpony/squidgrid/LOS.java
@@ -339,8 +339,8 @@ public class LOS {
     private boolean thickReachable(Radius radiusStrategy) {
         lastPath = new LinkedList<>();
         double dist = radiusStrategy.radius(startx, starty, targetx, targety), decay = 1 / dist;
-        LinkedHashSet<Coord> visited = new LinkedHashSet<Coord>((int) dist + 3);
-        List<List<Coord>> paths = new ArrayList<List<Coord>>(4);
+        LinkedHashSet<Coord> visited = new LinkedHashSet<>((int) dist + 3);
+        List<List<Coord>> paths = new ArrayList<>(4);
         /* // actual corners
         paths.add(DDALine.line(startx, starty, targetx, targety, 0, 0));
         paths.add(DDALine.line(startx, starty, targetx, targety, 0, 0xffff));
@@ -387,8 +387,8 @@ public class LOS {
     private boolean brushReachable(Radius radiusStrategy, int spread) {
         lastPath = new LinkedList<>();
         double dist = radiusStrategy.radius(startx, starty, targetx, targety) + spread * 2, decay = 1 / dist;
-        LinkedHashSet<Coord> visited = new LinkedHashSet<Coord>((int)(dist + 3) * spread);
-        List<List<Coord>> paths = new ArrayList<List<Coord>>((int)(radiusStrategy.volume2D(spread) * 1.25));
+        LinkedHashSet<Coord> visited = new LinkedHashSet<>((int) (dist + 3) * spread);
+        List<List<Coord>> paths = new ArrayList<>((int) (radiusStrategy.volume2D(spread) * 1.25));
         int length = 0;
         List<Coord> currentPath;
         for (int i = -spread; i <= spread; i++) {

--- a/squidlib-util/src/main/java/squidpony/squidgrid/MultiSpill.java
+++ b/squidlib-util/src/main/java/squidpony/squidgrid/MultiSpill.java
@@ -80,7 +80,7 @@ public class MultiSpill {
     public MultiSpill() {
         rng = new StatefulRNG();
 
-        fresh = new ArrayList<LinkedHashSet<Coord>>();
+        fresh = new ArrayList<>();
     }
     /**
      * Construct a Spill without a level to actually scan. This constructor allows you to specify an RNG, but the actual
@@ -93,7 +93,7 @@ public class MultiSpill {
     public MultiSpill(RNG random) {
         rng = new StatefulRNG(random.getRandomness());
 
-        fresh = new ArrayList<LinkedHashSet<Coord>>();
+        fresh = new ArrayList<>();
     }
 
     /**
@@ -189,7 +189,7 @@ public class MultiSpill {
      * @return this for chaining
      */
     public MultiSpill initialize(final short[][] level) {
-        fresh = new ArrayList<LinkedHashSet<Coord>>();
+        fresh = new ArrayList<>();
         width = level.length;
         height = level[0].length;
         spillMap = new short[width][height];
@@ -214,7 +214,7 @@ public class MultiSpill {
      * @return this for chaining
      */
     public MultiSpill initialize(final char[][] level) {
-        fresh = new ArrayList<LinkedHashSet<Coord>>();
+        fresh = new ArrayList<>();
         width = level.length;
         height = level[0].length;
         spillMap = new short[width][height];
@@ -241,7 +241,7 @@ public class MultiSpill {
      * @return this for chaining
      */
     public MultiSpill initialize(final char[][] level, char alternateWall) {
-        fresh = new ArrayList<LinkedHashSet<Coord>>();
+        fresh = new ArrayList<>();
         width = level.length;
         height = level[0].length;
         spillMap = new short[width][height];
@@ -340,8 +340,8 @@ public class MultiSpill {
             impassable = new LinkedHashSet<>();
         if(volume < 0)
             volume = Integer.MAX_VALUE;
-        ArrayList<Coord> spillers = new ArrayList<Coord>(entries);
-        spreadPattern = new ArrayList<ArrayList<Coord>>(spillers.size());
+        ArrayList<Coord> spillers = new ArrayList<>(entries);
+        spreadPattern = new ArrayList<>(spillers.size());
         fresh.clear();
         for (short i = 0; i < spillers.size(); i++) {
             spreadPattern.add(new ArrayList<Coord>(128));
@@ -422,11 +422,11 @@ public class MultiSpill {
             impassable = new LinkedHashSet<>();
         if(volume < 0)
             volume = Integer.MAX_VALUE;
-        ArrayList<Coord> spillers0 = new ArrayList<Coord>(entries.keySet()),
-                spillers = new ArrayList<Coord>(spillers0.size());
-        ArrayList<Double> biases0 = new ArrayList<Double>(entries.values()),
-                biases = new ArrayList<Double>(biases0.size());
-        spreadPattern = new ArrayList<ArrayList<Coord>>(spillers0.size());
+        ArrayList<Coord> spillers0 = new ArrayList<>(entries.keySet()),
+                spillers = new ArrayList<>(spillers0.size());
+        ArrayList<Double> biases0 = new ArrayList<>(entries.values()),
+                biases = new ArrayList<>(biases0.size());
+        spreadPattern = new ArrayList<>(spillers0.size());
         fresh.clear();
         for (short i = 0, ctr = 0; i < spillers0.size(); i++, ctr++) {
             spreadPattern.add(new ArrayList<Coord>(128));

--- a/squidlib-util/src/main/java/squidpony/squidgrid/Radius.java
+++ b/squidlib-util/src/main/java/squidpony/squidgrid/Radius.java
@@ -227,7 +227,7 @@ public enum Radius {
 
     public Set<Coord> perimeter(Coord center, int radiusLength, boolean surpassEdges, int width, int height)
     {
-        LinkedHashSet<Coord> rim = new LinkedHashSet<Coord>(4 * radiusLength);
+        LinkedHashSet<Coord> rim = new LinkedHashSet<>(4 * radiusLength);
         if(!surpassEdges && (center.x < 0 || center.x >= width || center.y < 0 || center.y > height))
             return rim;
         if(radiusLength < 1) {

--- a/squidlib-util/src/main/java/squidpony/squidgrid/SoundMap.java
+++ b/squidlib-util/src/main/java/squidpony/squidgrid/SoundMap.java
@@ -62,7 +62,7 @@ public class SoundMap
      * The latest results of findAlerted(), with Coord keys representing the positions of creatures that were alerted
      * and Double values representing how loud the sound was when it reached them.
      */
-    public HashMap<Coord, Double> alerted = new HashMap<Coord, Double>();
+    public HashMap<Coord, Double> alerted = new HashMap<>();
     /**
      * Cells with no sound are always marked with 0.
      */
@@ -89,9 +89,9 @@ public class SoundMap
      */
     public SoundMap() {
         rng = new RNG(new LightRNG());
-        alerted = new HashMap<Coord, Double>();
-        fresh = new HashMap<Coord, Double>();
-        sounds = new HashMap<Coord, Double>();
+        alerted = new HashMap<>();
+        fresh = new HashMap<>();
+        sounds = new HashMap<>();
     }
 
     /**
@@ -100,9 +100,9 @@ public class SoundMap
      */
     public SoundMap(RNG random) {
         rng = random;
-        alerted = new HashMap<Coord, Double>();
-        fresh = new HashMap<Coord, Double>();
-        sounds = new HashMap<Coord, Double>();
+        alerted = new HashMap<>();
+        fresh = new HashMap<>();
+        sounds = new HashMap<>();
     }
 
     /**
@@ -111,9 +111,9 @@ public class SoundMap
      */
     public SoundMap(final double[][] level) {
         rng = new RNG(new LightRNG());
-        alerted = new HashMap<Coord, Double>();
-        fresh = new HashMap<Coord, Double>();
-        sounds = new HashMap<Coord, Double>();
+        alerted = new HashMap<>();
+        fresh = new HashMap<>();
+        sounds = new HashMap<>();
         initialize(level);
     }
     /**
@@ -124,9 +124,9 @@ public class SoundMap
     public SoundMap(final double[][] level, Measurement measurement) {
         rng = new RNG(new LightRNG());
         this.measurement = measurement;
-        alerted = new HashMap<Coord, Double>();
-        fresh = new HashMap<Coord, Double>();
-        sounds = new HashMap<Coord, Double>();
+        alerted = new HashMap<>();
+        fresh = new HashMap<>();
+        sounds = new HashMap<>();
         initialize(level);
     }
 
@@ -140,9 +140,9 @@ public class SoundMap
      */
     public SoundMap(final char[][] level) {
         rng = new RNG(new LightRNG());
-        alerted = new HashMap<Coord, Double>();
-        fresh = new HashMap<Coord, Double>();
-        sounds = new HashMap<Coord, Double>();
+        alerted = new HashMap<>();
+        fresh = new HashMap<>();
+        sounds = new HashMap<>();
         initialize(level);
     }
     /**
@@ -155,9 +155,9 @@ public class SoundMap
      */
     public SoundMap(final char[][] level, char alternateWall) {
         rng = new RNG(new LightRNG());
-        alerted = new HashMap<Coord, Double>();
-        fresh = new HashMap<Coord, Double>();
-        sounds = new HashMap<Coord, Double>();
+        alerted = new HashMap<>();
+        fresh = new HashMap<>();
+        sounds = new HashMap<>();
         initialize(level, alternateWall);
     }
 
@@ -173,9 +173,9 @@ public class SoundMap
     public SoundMap(final char[][] level, Measurement measurement) {
         rng = new RNG(new LightRNG());
         this.measurement = measurement;
-        alerted = new HashMap<Coord, Double>();
-        fresh = new HashMap<Coord, Double>();
-        sounds = new HashMap<Coord, Double>();
+        alerted = new HashMap<>();
+        fresh = new HashMap<>();
+        sounds = new HashMap<>();
         initialize(level);
     }
 
@@ -404,7 +404,7 @@ public class SoundMap
 
         while (numAssigned > 0) {
             numAssigned = 0;
-            HashMap<Coord, Double> fresh2 = new HashMap<Coord, Double>(fresh.size());
+            HashMap<Coord, Double> fresh2 = new HashMap<>(fresh.size());
             fresh2.putAll(fresh);
             fresh.clear();
 
@@ -451,7 +451,7 @@ public class SoundMap
      */
     public HashMap<Coord, Double> findAlerted(Set<Coord> creatures, Map<Coord, Double> extraSounds) {
         if(!initialized) return null;
-        alerted = new HashMap<Coord, Double>(creatures.size());
+        alerted = new HashMap<>(creatures.size());
 
         resetMap();
         for (Map.Entry<Coord, Double> sound : extraSounds.entrySet()) {

--- a/squidlib-util/src/main/java/squidpony/squidgrid/SpatialMap.java
+++ b/squidlib-util/src/main/java/squidpony/squidgrid/SpatialMap.java
@@ -64,8 +64,8 @@ public class SpatialMap<I, E> implements Iterable<E> {
      */
     public SpatialMap()
     {
-        itemMapping = new LinkedHashMap<I, SpatialTriple<I, E>>(32);
-        positionMapping = new LinkedHashMap<Coord, SpatialTriple<I, E>>(32);
+        itemMapping = new LinkedHashMap<>(32);
+        positionMapping = new LinkedHashMap<>(32);
     }
 
     /**
@@ -74,8 +74,8 @@ public class SpatialMap<I, E> implements Iterable<E> {
      */
     public SpatialMap(int capacity)
     {
-        itemMapping = new LinkedHashMap<I, SpatialTriple<I, E>>(capacity);
-        positionMapping = new LinkedHashMap<Coord, SpatialTriple<I, E>>(capacity);
+        itemMapping = new LinkedHashMap<>(capacity);
+        positionMapping = new LinkedHashMap<>(capacity);
     }
 
     /**
@@ -88,9 +88,9 @@ public class SpatialMap<I, E> implements Iterable<E> {
      */
     public SpatialMap(Coord[] coords, I[] ids, E[] elements)
     {
-        itemMapping = new LinkedHashMap<I, SpatialTriple<I, E>>(
+        itemMapping = new LinkedHashMap<>(
                 Math.min(coords.length, Math.min(ids.length, elements.length)));
-        positionMapping = new LinkedHashMap<Coord, SpatialTriple<I, E>>(
+        positionMapping = new LinkedHashMap<>(
                 Math.min(coords.length, Math.min(ids.length, elements.length)));
 
         for (int i = 0; i < coords.length && i < ids.length && i < elements.length; i++) {
@@ -109,9 +109,9 @@ public class SpatialMap<I, E> implements Iterable<E> {
      */
     public SpatialMap(Collection<Coord> coords, Collection<I> ids, Collection<E> elements)
     {
-        itemMapping = new LinkedHashMap<I, SpatialTriple<I, E>>(
+        itemMapping = new LinkedHashMap<>(
                 Math.min(coords.size(), Math.min(ids.size(), elements.size())));
-        positionMapping = new LinkedHashMap<Coord, SpatialTriple<I, E>>(
+        positionMapping = new LinkedHashMap<>(
                 Math.min(coords.size(), Math.min(ids.size(), elements.size())));
         if(itemMapping.size() <= 0)
             return;
@@ -142,7 +142,7 @@ public class SpatialMap<I, E> implements Iterable<E> {
             return;
         if(positionMapping.get(coord) == null)
         {
-            SpatialTriple<I, E> triple = new SpatialTriple<I, E>(coord, id, element);
+            SpatialTriple<I, E> triple = new SpatialTriple<>(coord, id, element);
             itemMapping.put(id, triple);
             positionMapping.put(coord, triple);
         }
@@ -158,7 +158,7 @@ public class SpatialMap<I, E> implements Iterable<E> {
      */
     public void put(Coord coord, I id, E element)
     {
-        SpatialTriple<I, E> triple = new SpatialTriple<I, E>(coord, id, element);
+        SpatialTriple<I, E> triple = new SpatialTriple<>(coord, id, element);
         itemMapping.remove(id);
         positionMapping.remove(coord);
         itemMapping.put(id, triple);
@@ -373,7 +373,7 @@ public class SpatialMap<I, E> implements Iterable<E> {
      */
     public LinkedHashSet<Coord> positions()
     {
-        return new LinkedHashSet<Coord>(positionMapping.keySet());
+        return new LinkedHashSet<>(positionMapping.keySet());
     }
     /**
      * Get a Set of all identities used for values in this data structure, returning a LinkedHashSet (defensively
@@ -382,7 +382,7 @@ public class SpatialMap<I, E> implements Iterable<E> {
      */
     public LinkedHashSet<I> identities()
     {
-        return new LinkedHashSet<I>(itemMapping.keySet());
+        return new LinkedHashSet<>(itemMapping.keySet());
     }
 
     /**

--- a/squidlib-util/src/main/java/squidpony/squidgrid/Spill.java
+++ b/squidlib-util/src/main/java/squidpony/squidgrid/Spill.java
@@ -381,7 +381,7 @@ public class Spill {
             impassable = new LinkedHashSet<>();
         if(!physicalMap[entry.x][entry.y] || impassable.contains(entry))
             return null;
-        spreadPattern = new ArrayList<Coord>(volume);
+        spreadPattern = new ArrayList<>(volume);
         spillMap[entry.x][entry.y] = true;
         Coord temp;
         for(int x = 0; x < spillMap.length; x++)

--- a/squidlib-util/src/main/java/squidpony/squidgrid/Splash.java
+++ b/squidlib-util/src/main/java/squidpony/squidgrid/Splash.java
@@ -27,7 +27,7 @@ public class Splash {
 	 * A fresh instance, whose only impassable character is '#'.
 	 */
 	public Splash() {
-		this.impassable = new HashSet<Character>();
+		this.impassable = new HashSet<>();
 		/* The default */
 		addImpassableChar('#');
 	}
@@ -37,7 +37,7 @@ public class Splash {
 	 * {@link #removeImpassableChar(char)} if you use '#' to mean something non-blocking.
 	 */
 	public Splash(Set<Character> blocked) {
-		this.impassable = new HashSet<Character>(blocked);
+		this.impassable = new HashSet<>(blocked);
 		/* The default */
 		addImpassableChar('#');
 	}
@@ -82,13 +82,13 @@ public class Splash {
 		if (!DungeonUtility.inLevel(level, start) || !passable(level[start.x][start.y]))
 			return Collections.emptyList();
 
-		final List<Coord> result = new ArrayList<Coord>(volume);
+		final List<Coord> result = new ArrayList<>(volume);
 
 		Direction[] dirs = new Direction[Direction.OUTWARDS.length];
 
-		final LinkedList<Coord> toTry = new LinkedList<Coord>();
+		final LinkedList<Coord> toTry = new LinkedList<>();
 		toTry.add(start);
-		final Set<Coord> trieds = new HashSet<Coord>();
+		final Set<Coord> trieds = new HashSet<>();
 
 		while (!toTry.isEmpty()) {
 			assert result.size() < volume;
@@ -147,7 +147,7 @@ public class Splash {
 	{
 		Set<Character> blocked;
 		if(impassable == null)
-			blocked = new HashSet<Character>(2);
+			blocked = new HashSet<>(2);
 		else
 			blocked = impassable;
 		if(splashCache == null || blocked.hashCode() != splashHash)

--- a/squidlib-util/src/main/java/squidpony/squidgrid/mapping/DividedMazeGenerator.java
+++ b/squidlib-util/src/main/java/squidpony/squidgrid/mapping/DividedMazeGenerator.java
@@ -66,8 +66,8 @@ public class DividedMazeGenerator {
         stack.offer(new DividedMazeRoom(1, 1, width - 2, height - 2));
         while (!stack.isEmpty()) {
             DividedMazeRoom room = stack.pop();
-            ArrayList<Integer> availX = new ArrayList<Integer>(),
-                               availY = new ArrayList<Integer>();
+            ArrayList<Integer> availX = new ArrayList<>(),
+                               availY = new ArrayList<>();
 
             for (int x = room.left + 1; x < room.right; x++) {
                 boolean top = map[x][room.top - 1];

--- a/squidlib-util/src/main/java/squidpony/squidgrid/mapping/DungeonGenerator.java
+++ b/squidlib-util/src/main/java/squidpony/squidgrid/mapping/DungeonGenerator.java
@@ -146,7 +146,7 @@ public class DungeonGenerator {
         rebuildSeed = rng.getState();
         height = 40;
         width = 40;
-        fx = new EnumMap<FillEffect, Integer>(FillEffect.class);
+        fx = new EnumMap<>(FillEffect.class);
     }
 
     /**
@@ -175,7 +175,7 @@ public class DungeonGenerator {
         rebuildSeed = this.rng.getState();
         this.height = height;
         this.width = width;
-        fx = new EnumMap<FillEffect, Integer>(FillEffect.class);
+        fx = new EnumMap<>(FillEffect.class);
     }
 
     /**
@@ -190,7 +190,7 @@ public class DungeonGenerator {
         rebuildSeed = rng.getState();
         height = copying.height;
         width = copying.width;
-        fx = new EnumMap<FillEffect, Integer>(copying.fx);
+        fx = new EnumMap<>(copying.fx);
         dungeon = copying.dungeon;
     }
 
@@ -348,7 +348,7 @@ public class DungeonGenerator {
 
     private LinkedHashSet<Coord> viableDoorways(boolean doubleDoors, char[][] map)
     {
-        LinkedHashSet<Coord> doors = new LinkedHashSet<Coord>();
+        LinkedHashSet<Coord> doors = new LinkedHashSet<>();
         for(int x = 1; x < map.length - 1; x++) {
             for (int y = 1; y < map[x].length - 1; y++) {
                 if(map[x][y] == '#')
@@ -528,9 +528,9 @@ public class DungeonGenerator {
     private char[][] innerGenerate(char[][] map)
     {
 
-        LinkedHashSet<Coord> floors = new LinkedHashSet<Coord>();
+        LinkedHashSet<Coord> floors = new LinkedHashSet<>();
         LinkedHashSet<Coord> doorways;
-        LinkedHashSet<Coord> hazards = new LinkedHashSet<Coord>();
+        LinkedHashSet<Coord> hazards = new LinkedHashSet<>();
         Coord temp;
         boolean doubleDoors = false;
         int doorFill = 0;
@@ -573,7 +573,7 @@ public class DungeonGenerator {
         floorRate -= waterRate + grassRate;
         doorways = viableDoorways(doubleDoors, map);
 
-        LinkedHashSet<Coord> obstacles = new LinkedHashSet<Coord>(doorways.size() * doorFill / 100);
+        LinkedHashSet<Coord> obstacles = new LinkedHashSet<>(doorways.size() * doorFill / 100);
         if(doorFill > 0)
         {
             int total = doorways.size() * doorFill / 100;
@@ -641,7 +641,7 @@ public class DungeonGenerator {
         }
 
         MultiSpill ms = new MultiSpill(map, Spill.Measurement.MANHATTAN, rng);
-        LinkedHashMap<Coord, Double> fillers = new LinkedHashMap<Coord, Double>(128);
+        LinkedHashMap<Coord, Double> fillers = new LinkedHashMap<>(128);
         ArrayList<Coord> dots = PoissonDisk.sampleMap(map, Math.min(width, height) / 8f, rng, '#', '+', '/','<', '>');
         for (int i = 0; i < dots.size(); i++) {
             switch (i % 3) {
@@ -741,9 +741,9 @@ public class DungeonGenerator {
 	private char[][] innerGenerateOld(char[][] map)
     {
 
-        LinkedHashSet<Coord> floors = new LinkedHashSet<Coord>();
+        LinkedHashSet<Coord> floors = new LinkedHashSet<>();
         LinkedHashSet<Coord> doorways;
-        LinkedHashSet<Coord> hazards = new LinkedHashSet<Coord>();
+        LinkedHashSet<Coord> hazards = new LinkedHashSet<>();
         Coord temp;
         boolean doubleDoors = false;
         int doorFill = 0;
@@ -775,7 +775,7 @@ public class DungeonGenerator {
 
         doorways = viableDoorways(doubleDoors, map);
 
-        LinkedHashSet<Coord> obstacles = new LinkedHashSet<Coord>(doorways.size() * doorFill / 100);
+        LinkedHashSet<Coord> obstacles = new LinkedHashSet<>(doorways.size() * doorFill / 100);
         if(doorFill > 0)
         {
             int total = doorways.size() * doorFill / 100;
@@ -861,7 +861,7 @@ public class DungeonGenerator {
                 Coord entry = floors.toArray(new Coord[floors.size()])[rng.nextInt(floors.size())];
                 spill.start(entry, volumes[i] / 3, obstacles);
                 spill.start(entry, 2 * volumes[i] / 3, obstacles);
-                ArrayList<Coord> ordered = new ArrayList<Coord>(spill.start(entry, volumes[i], obstacles));
+                ArrayList<Coord> ordered = new ArrayList<>(spill.start(entry, volumes[i], obstacles));
                 floors.removeAll(ordered);
                 hazards.removeAll(ordered);
                 obstacles.addAll(ordered);
@@ -918,7 +918,7 @@ public class DungeonGenerator {
                 Coord entry = floors.toArray(new Coord[floors.size()])[rng.nextInt(floors.size())];
 //                spill.start(entry, volumes[i] / 3, obstacles);
 //                spill.start(entry, 2 * volumes[i] / 3, obstacles);
-                ArrayList<Coord> ordered = new ArrayList<Coord>(spill.start(entry, volumes[i], obstacles));
+                ArrayList<Coord> ordered = new ArrayList<>(spill.start(entry, volumes[i], obstacles));
                 floors.removeAll(ordered);
                 hazards.removeAll(ordered);
                 obstacles.addAll(ordered);

--- a/squidlib-util/src/main/java/squidpony/squidgrid/mapping/MixedGenerator.java
+++ b/squidlib-util/src/main/java/squidpony/squidgrid/mapping/MixedGenerator.java
@@ -90,12 +90,12 @@ public class MixedGenerator {
             System.arraycopy(dungeon[0], 0, dungeon[i], 0, height);
         }
         totalPoints = sequence.size() - 1;
-        points = new ArrayList<Long>(totalPoints);
+        points = new ArrayList<>(totalPoints);
         for (int i = 0; i < totalPoints; i++) {
             Coord c1 = sequence.get(i), c2 = sequence.get(i + 1);
             points.add(((c1.x & 0xffL) << 24) | ((c1.y & 0xff) << 16) | ((c2.x & 0xff) << 8) | (c2.y & 0xff));
         }
-        carvers = new EnumMap<CarverType, Integer>(CarverType.class);
+        carvers = new EnumMap<>(CarverType.class);
     }
     /**
      * This prepares a map generator that will generate a map with the given width and height, using the given RNG.
@@ -148,14 +148,14 @@ public class MixedGenerator {
         {
             totalPoints += vals.size();
         }
-        points = new ArrayList<Long>(totalPoints);
+        points = new ArrayList<>(totalPoints);
         for (Map.Entry<Coord, List<Coord>> kv : connections.entrySet()) {
             Coord c1 = kv.getKey();
             for (Coord c2 : kv.getValue()) {
                 points.add(((c1.x & 0xffL) << 24) | ((c1.y & 0xff) << 16) | ((c2.x & 0xff) << 8) | (c2.y & 0xff));
             }
         }
-        carvers = new EnumMap<CarverType, Integer>(CarverType.class);
+        carvers = new EnumMap<>(CarverType.class);
     }
 
     /**

--- a/squidlib-util/src/main/java/squidpony/squidgrid/mapping/SerpentDeepMapGenerator.java
+++ b/squidlib-util/src/main/java/squidpony/squidgrid/mapping/SerpentDeepMapGenerator.java
@@ -76,8 +76,8 @@ public class SerpentDeepMapGenerator {
 
         columns = new int[16];
         rows = new int[16];
-        linksUp = new ArrayList<LinkedHashSet<Coord>>(depth);
-        linksDown = new ArrayList<LinkedHashSet<Coord>>(depth);
+        linksUp = new ArrayList<>(depth);
+        linksDown = new ArrayList<>(depth);
         for (int i = 0; i < depth; i++) {
             linksUp.add(new LinkedHashSet<Coord>(80));
             linksDown.add(new LinkedHashSet<Coord>(80));
@@ -106,7 +106,7 @@ public class SerpentDeepMapGenerator {
             rows[i] += rs3;
         }
 
-        List<LinkedHashMap<Coord, List<Coord>>> connections = new ArrayList<LinkedHashMap<Coord, List<Coord>>>(depth);
+        List<LinkedHashMap<Coord, List<Coord>>> connections = new ArrayList<>(depth);
         for (int i = 0; i < depth; i++) {
             connections.add(new LinkedHashMap<Coord, List<Coord>>(80));
         }
@@ -120,7 +120,7 @@ public class SerpentDeepMapGenerator {
             tz = z;
             int tx = x, ty = y;
             do {
-                List<Coord> cl = new ArrayList<Coord>(4);
+                List<Coord> cl = new ArrayList<>(4);
 
                 for (int j = 0;
                      j < 2;
@@ -142,7 +142,7 @@ public class SerpentDeepMapGenerator {
                 if(connect != null)
                     connections.get(tz).get(Coord.get(columns[tx], rows[ty])).addAll(cl);
                 else
-                    connections.get(tz).put(Coord.get(columns[tx], rows[ty]), new ArrayList<Coord>(cl));
+                    connections.get(tz).put(Coord.get(columns[tx], rows[ty]), new ArrayList<>(cl));
 
                 x = CoordPacker.getXMoore3D(m, numLayers);
                 y = CoordPacker.getYMoore3D(m, numLayers);
@@ -156,7 +156,7 @@ public class SerpentDeepMapGenerator {
                     if(conn != null)
                         connections.get(z).get(Coord.get(columns[tx], rows[ty])).addAll(cl);
                     else
-                        connections.get(z).put(Coord.get(columns[tx], rows[ty]), new ArrayList<Coord>(cl));
+                        connections.get(z).put(Coord.get(columns[tx], rows[ty]), new ArrayList<>(cl));
                     break;
                 }
                 else {
@@ -176,7 +176,7 @@ public class SerpentDeepMapGenerator {
         }
 
         do {
-            List<Coord> cl = new ArrayList<Coord>(4);
+            List<Coord> cl = new ArrayList<>(4);
 
             for (int j = 0;
                  j < 2;
@@ -198,7 +198,7 @@ public class SerpentDeepMapGenerator {
             if(connect != null)
                 connections.get(tz).get(Coord.get(columns[x], rows[y])).addAll(cl);
             else
-                connections.get(tz).put(Coord.get(columns[x], rows[y]), new ArrayList<Coord>(cl));
+                connections.get(tz).put(Coord.get(columns[x], rows[y]), new ArrayList<>(cl));
 
             if(sz != tz)
                 cl.clear();
@@ -340,14 +340,14 @@ public class SerpentDeepMapGenerator {
             floors[i] = CoordPacker.pack(dungeon[i], '.');
         }
         //using actual dungeon space per layer, not row/column 3D grid space
-        ArrayList<LinkedHashSet<Coord>> ups = new ArrayList<LinkedHashSet<Coord>>(depth),
-                downs = new ArrayList<LinkedHashSet<Coord>>(depth);
+        ArrayList<LinkedHashSet<Coord>> ups = new ArrayList<>(depth),
+                downs = new ArrayList<>(depth);
         for (int i = 0; i < depth; i++) {
             ups.add(new LinkedHashSet<Coord>(40));
             downs.add(new LinkedHashSet<Coord>(40));
             LinkedHashSet<Coord> above = null;
             if (i > 0) {
-                above = new LinkedHashSet<Coord>(linksDown.get(i - 1));
+                above = new LinkedHashSet<>(linksDown.get(i - 1));
                 if(above.size() == 0)
                     continue;
                 Coord higher = random.getRandomElement(above.toArray(new Coord[above.size()]));
@@ -375,7 +375,7 @@ public class SerpentDeepMapGenerator {
         }
 
         for (int i = 0; i < depth; i++) {
-            LinkedHashMap<Coord, Integer> used = new LinkedHashMap<Coord, Integer>(128);
+            LinkedHashMap<Coord, Integer> used = new LinkedHashMap<>(128);
             for(Coord up : ups.get(i))
             {
                 Integer count = used.get(up);

--- a/squidlib-util/src/main/java/squidpony/squidgrid/mapping/SerpentMapGenerator.java
+++ b/squidlib-util/src/main/java/squidpony/squidgrid/mapping/SerpentMapGenerator.java
@@ -85,7 +85,7 @@ public class SerpentMapGenerator {
             rows[i] += rs3;
         }
 
-        List<Coord> points = new ArrayList<Coord>(80);
+        List<Coord> points = new ArrayList<>(80);
         Coord temp;
         for (int i = 0, m = random.nextInt(64), r; i < 256; r = random.between(4, 12), i += r, m += r) {
             temp = CoordPacker.mooreToCoord(m);
@@ -165,14 +165,14 @@ public class SerpentMapGenerator {
             rows[i] += rs3;
         }
 
-        LinkedHashMap<Coord, List<Coord>> connections = new LinkedHashMap<Coord, List<Coord>>(80);
+        LinkedHashMap<Coord, List<Coord>> connections = new LinkedHashMap<>(80);
         Coord temp, t;
         int m = random.nextInt(64), r = random.between(4, 12);
         temp = CoordPacker.mooreToCoord(m);
         Coord starter = CoordPacker.mooreToCoord(m);
         m += r;
         for (int i = r; i < 256; i += r, m += r) {
-            List<Coord> cl = new ArrayList<Coord>(4);
+            List<Coord> cl = new ArrayList<>(4);
             cl.add(Coord.get(columns[temp.x], rows[temp.y]));
             temp = CoordPacker.mooreToCoord(m);
             r = random.between(4, 12);

--- a/squidlib-util/src/main/java/squidpony/squidgrid/mapping/SymmetryDungeonGenerator.java
+++ b/squidlib-util/src/main/java/squidpony/squidgrid/mapping/SymmetryDungeonGenerator.java
@@ -17,7 +17,7 @@ public class SymmetryDungeonGenerator extends MixedGenerator {
 
     public static LinkedHashMap<Coord, List<Coord>> removeSomeOverlap(int width, int height, List<Coord> sequence)
     {
-        List<Coord> s2 = new ArrayList<Coord>(sequence.size());
+        List<Coord> s2 = new ArrayList<>(sequence.size());
         for(Coord c : sequence)
         {
             if(c.x * 1.0 / width + c.y * 1.0 / height <= 1.0)
@@ -26,7 +26,7 @@ public class SymmetryDungeonGenerator extends MixedGenerator {
         return listToMap(s2);
     }
     public static LinkedHashMap<Coord, List<Coord>> removeSomeOverlap(int width, int height, LinkedHashMap<Coord, List<Coord>> connections) {
-        LinkedHashMap<Coord, List<Coord>> lhm2 = new LinkedHashMap<Coord, List<Coord>>(connections.size());
+        LinkedHashMap<Coord, List<Coord>> lhm2 = new LinkedHashMap<>(connections.size());
         Set<Coord> keyset = connections.keySet(), newkeys = new LinkedHashSet<>(connections.size());
         for (Coord c : keyset) {
             if (c.x * 1.0 / width + c.y * 1.0 / height <= 1.0) {
@@ -37,7 +37,7 @@ public class SymmetryDungeonGenerator extends MixedGenerator {
         for (int i = 0; i < keys.length; i++) {
             Coord c = keys[i];
             if (c.x * 1.0 / width + c.y * 1.0 / height <= 1.0) {
-                List<Coord> cs = new ArrayList<Coord>(4);
+                List<Coord> cs = new ArrayList<>(4);
                 for (Coord c2 : connections.get(c)) {
                     if (c2.x * 1.0 / width + c2.y * 1.0 / height <= 1.0) {
                         cs.add(c2);
@@ -125,10 +125,10 @@ public class SymmetryDungeonGenerator extends MixedGenerator {
 
     protected static LinkedHashMap<Coord, List<Coord>> listToMap(List<Coord> sequence)
     {
-        LinkedHashMap<Coord, List<Coord>> conns = new LinkedHashMap<Coord, List<Coord>>(sequence.size() - 1);
+        LinkedHashMap<Coord, List<Coord>> conns = new LinkedHashMap<>(sequence.size() - 1);
         for (int i = 0; i < sequence.size() - 1; i++) {
             Coord c1 = sequence.get(i), c2 = sequence.get(i+1);
-            List<Coord> cs = new ArrayList<Coord>(1);
+            List<Coord> cs = new ArrayList<>(1);
             cs.add(c2);
             conns.put(c1, cs);
         }
@@ -137,10 +137,10 @@ public class SymmetryDungeonGenerator extends MixedGenerator {
 
     protected static LinkedHashMap<Coord, List<Coord>> crossConnect(int width, int height, LinkedHashMap<Coord, List<Coord>> connections)
     {
-        LinkedHashMap<Coord, List<Coord>> conns = new LinkedHashMap<Coord, List<Coord>>(connections.size());
+        LinkedHashMap<Coord, List<Coord>> conns = new LinkedHashMap<>(connections.size());
         for(Map.Entry<Coord, List<Coord>> entry : connections.entrySet())
         {
-            conns.put(entry.getKey(), new ArrayList<Coord>(entry.getValue()));
+            conns.put(entry.getKey(), new ArrayList<>(entry.getValue()));
         }
         double lowest1 = 9999, lowest2 = 9999, lowest3 = 9999, lowest4 = 9999;
         Coord l1 = null, l2 = null, l3 = null, l4 = null, r1 = null, r2 = null, r3 = null, r4 = null;

--- a/squidlib-util/src/main/java/squidpony/squidmath/AStarSearch.java
+++ b/squidlib-util/src/main/java/squidpony/squidmath/AStarSearch.java
@@ -154,7 +154,7 @@ public class AStarSearch {
         }
 
         /* Not using Deque nor ArrayDeqye, they aren't Gwt compatible */
-        final LinkedList<Coord> deq = new LinkedList<Coord>();
+        final LinkedList<Coord> deq = new LinkedList<>();
         while (!p.equals(start)) {
             deq.addFirst(p);
             p = parent[p.x][p.y];

--- a/squidlib-util/src/main/java/squidpony/squidmath/CoordPacker.java
+++ b/squidlib-util/src/main/java/squidpony/squidmath/CoordPacker.java
@@ -1234,7 +1234,7 @@ public class CoordPacker {
      */
     public static ArrayList<short[]> findManyPacked(int x, int y, short[] ... packed)
     {
-        ArrayList<short[]> packs = new ArrayList<short[]>(packed.length);
+        ArrayList<short[]> packs = new ArrayList<>(packed.length);
         int hilbertDistance = posToHilbert(x, y);
         for (int a = 0; a < packed.length; a++) {
             if(packed[a] == null) continue;
@@ -1266,7 +1266,7 @@ public class CoordPacker {
      */
     public static ArrayList<short[]> findManyPackedHilbert(short hilbert, short[] ... packed)
     {
-        ArrayList<short[]> packs = new ArrayList<short[]>(packed.length);
+        ArrayList<short[]> packs = new ArrayList<>(packed.length);
         int hilbertDistance = hilbert & 0xffff;
         for (int a = 0; a < packed.length; a++) {
             int total = 0;
@@ -3742,7 +3742,7 @@ public class CoordPacker {
      */
     public static ArrayList<short[]> split(short[] packed)
     {
-        ArrayList<short[]> arrays = new ArrayList<short[]>(32);
+        ArrayList<short[]> arrays = new ArrayList<>(32);
         short[] remaining = Arrays.copyOf(packed, packed.length);
         while (remaining.length > 1) {
             boolean on = false;
@@ -3838,7 +3838,7 @@ public class CoordPacker {
     public static ArrayList<Coord> randomPortion(short[] packed, int size, RNG rng)
     {
         int counted = count(packed);
-        ArrayList<Coord> coords = new ArrayList<Coord>(Math.min(counted, size));
+        ArrayList<Coord> coords = new ArrayList<>(Math.min(counted, size));
         if(counted == 0 || size == 0)
             return coords;
         int[] data = rng.randomRange(0, counted, Math.min(counted, size));

--- a/squidlib-util/src/main/java/squidpony/squidmath/DDALine.java
+++ b/squidlib-util/src/main/java/squidpony/squidmath/DDALine.java
@@ -35,7 +35,7 @@ public class DDALine {
         int dx = endX - startX, dy = endY - startY, nx = Math.abs(dx), ny = Math.abs(dy),
                 octant = ((dy < 0) ? 4 : 0) | ((dx < 0) ? 2 : 0) | ((ny > nx) ? 1 : 0), move, frac = 0;
 
-        LinkedList<Coord> drawn = new LinkedList<Coord>();
+        LinkedList<Coord> drawn = new LinkedList<>();
         switch (octant)
         {
             // x positive, y positive

--- a/squidlib-util/src/main/java/squidpony/squidmath/DeckRNG.java
+++ b/squidlib-util/src/main/java/squidpony/squidmath/DeckRNG.java
@@ -183,7 +183,7 @@ public class DeckRNG extends StatefulRNG {
         if (list.isEmpty()) {
             return null;
         }
-        return new ArrayList<T>(list).get(nextInt(list.size()));
+        return new ArrayList<>(list).get(nextInt(list.size()));
     }
 
     /**

--- a/squidlib-util/src/main/java/squidpony/squidmath/DharmaRNG.java
+++ b/squidlib-util/src/main/java/squidpony/squidmath/DharmaRNG.java
@@ -234,7 +234,7 @@ public class DharmaRNG extends RNG {
         if (list.isEmpty()) {
             return null;
         }
-        return new ArrayList<T>(list).get(nextInt(list.size()));
+        return new ArrayList<>(list).get(nextInt(list.size()));
     }
 
     /**

--- a/squidlib-util/src/main/java/squidpony/squidmath/OrthoLine.java
+++ b/squidlib-util/src/main/java/squidpony/squidmath/OrthoLine.java
@@ -22,7 +22,7 @@ public class OrthoLine {
     public static List<Coord> line(int startX, int startY, int endX, int endY) {
         int dx = endX - startX, dy = endY - startY, nx = Math.abs(dx), ny = Math.abs(dy);
         int signX = (dx > 0) ? 1 : -1, signY = (dy > 0) ? 1 : -1, workX = startX, workY = startY;
-        LinkedList<Coord> drawn = new LinkedList<Coord>();
+        LinkedList<Coord> drawn = new LinkedList<>();
         drawn.add(Coord.get(startX, startY));
         for (int ix = 0, iy = 0; ix < nx || iy < ny; ) {
             if ((0.5f + ix) / nx < (0.5 + iy) / ny) {

--- a/squidlib-util/src/main/java/squidpony/squidmath/PoissonDisk.java
+++ b/squidlib-util/src/main/java/squidpony/squidmath/PoissonDisk.java
@@ -118,8 +118,8 @@ public class PoissonDisk {
         int gridWidth = (int)(dimensions.x / cellSize) + 1;
         int gridHeight = (int)(dimensions.y / cellSize) + 1;
         Coord[][] grid = new Coord[gridWidth][gridHeight];
-        ArrayList<Coord> activePoints = new ArrayList<Coord>();
-        LinkedHashSet<Coord> points = new LinkedHashSet<Coord>(128);
+        ArrayList<Coord> activePoints = new ArrayList<>();
+        LinkedHashSet<Coord> points = new LinkedHashSet<>(128);
 
         //add first point
         boolean added = false;
@@ -194,7 +194,7 @@ public class PoissonDisk {
             if (!found)
                 activePoints.remove(listIndex);
         }
-        activePoints = new ArrayList<Coord>(points);
+        activePoints = new ArrayList<>(points);
         return activePoints;
     }
 
@@ -209,7 +209,7 @@ public class PoissonDisk {
                                              float minimumDistance, RNG rng, Character... blocking) {
         int width = map.length;
         int height = map[0].length;
-        HashSet<Character> blocked = new HashSet<Character>();
+        HashSet<Character> blocked = new HashSet<>();
         Collections.addAll(blocked, blocking);
         boolean restricted = false;
         if (blocked.size() > 0) {
@@ -220,8 +220,8 @@ public class PoissonDisk {
         int gridWidth = (int) (dimensions.x / cellSize) + 1;
         int gridHeight = (int) (dimensions.y / cellSize) + 1;
         Coord[][] grid = new Coord[gridWidth][gridHeight];
-        ArrayList<Coord> activePoints = new ArrayList<Coord>();
-        LinkedHashSet<Coord> points = new LinkedHashSet<Coord>(128);
+        ArrayList<Coord> activePoints = new ArrayList<>();
+        LinkedHashSet<Coord> points = new LinkedHashSet<>(128);
 
         //add first point
 
@@ -294,7 +294,7 @@ public class PoissonDisk {
             if (!found)
                 activePoints.remove(listIndex);
         }
-        activePoints = new ArrayList<Coord>(points);
+        activePoints = new ArrayList<>(points);
         return activePoints;
     }
     /**

--- a/squidlib-util/src/main/java/squidpony/squidmath/RNG.java
+++ b/squidlib-util/src/main/java/squidpony/squidmath/RNG.java
@@ -237,7 +237,7 @@ public class RNG implements Serializable {
         if (list.isEmpty()) {
             return null;
         }
-        return new ArrayList<T>(list).get(nextInt(list.size()));
+        return new ArrayList<>(list).get(nextInt(list.size()));
     }
 
 	/**
@@ -267,7 +267,7 @@ public class RNG implements Serializable {
 		 * Collections.rotate should prefer the best-performing way to rotate l, which would be an in-place
 		 * modification for ArrayLists and an append to a sublist for Lists that don't support efficient random access.
 		 */
-        List<T> l2 = new ArrayList<T>(l);
+        List<T> l2 = new ArrayList<>(l);
         Collections.rotate(l2, nextInt(sz));
         return l2;
 	}
@@ -389,7 +389,7 @@ public class RNG implements Serializable {
      */
     public <T> ArrayList<T> shuffle(List<T> elements)
     {
-        ArrayList<T> al = new ArrayList<T>(elements);
+        ArrayList<T> al = new ArrayList<>(elements);
         int n = al.size();
         for (int i = 0; i < n; i++)
         {

--- a/squidlib-util/src/main/java/squidpony/squidmath/RegionMap.java
+++ b/squidlib-util/src/main/java/squidpony/squidmath/RegionMap.java
@@ -344,7 +344,7 @@ public class RegionMap<V> implements Iterable<RegionMap.Entry<V>> {
      */
     public ArrayList<V> allAt(int x, int y)
     {
-        ArrayList<V> found = new ArrayList<V>(capacity);
+        ArrayList<V> found = new ArrayList<>(capacity);
         ArrayList<short[]> regions = CoordPacker.findManyPacked(x, y, keyTable);
         for(short[] region : regions)
         {
@@ -648,8 +648,8 @@ public class RegionMap<V> implements Iterable<RegionMap.Entry<V>> {
      * time this method is called. Use the {@link Entries} constructor for nested or multithreaded iteration. */
     public Entries<V> entries () {
         if (entries1 == null) {
-            entries1 = new Entries<V>(this);
-            entries2 = new Entries<V>(this);
+            entries1 = new Entries<>(this);
+            entries2 = new Entries<>(this);
         }
         if (!entries1.valid) {
             entries1.reset();
@@ -667,8 +667,8 @@ public class RegionMap<V> implements Iterable<RegionMap.Entry<V>> {
      * time this method is called. Use the {@link Values} constructor for nested or multithreaded iteration. */
     public Values<V> values () {
         if (values1 == null) {
-            values1 = new Values<V>(this);
-            values2 = new Values<V>(this);
+            values1 = new Values<>(this);
+            values2 = new Values<>(this);
         }
         if (!values1.valid) {
             values1.reset();
@@ -755,7 +755,7 @@ public class RegionMap<V> implements Iterable<RegionMap.Entry<V>> {
     }
 
     public static class Entries<V> extends MapIterator<V, Entry<V>> {
-        Entry<V> entry = new Entry<V>();
+        Entry<V> entry = new Entry<>();
 
         public Entries (RegionMap<V> map) {
             super(map);

--- a/squidlib-util/src/test/java/squidpony/examples/LOSComparisonTest.java
+++ b/squidlib-util/src/test/java/squidpony/examples/LOSComparisonTest.java
@@ -32,7 +32,7 @@ public class LOSComparisonTest {
             short[] flooded = CoordPacker.flood(floors, CoordPacker.packOne(start), 10, true);
             short[] outside = CoordPacker.differencePacked(CoordPacker.rectangle(width, height),// flooded);
                     CoordPacker.expand(flooded, 1, width, height));
-            ArrayList<Coord> allSeen = new ArrayList<Coord>(23 * 23), targets = new ArrayList<Coord>(5);
+            ArrayList<Coord> allSeen = new ArrayList<>(23 * 23), targets = new ArrayList<>(5);
             LOS los;
             if(l < 7) los = new LOS(l);
             else los = new LOS(6);

--- a/squidlib-util/src/test/java/squidpony/examples/SoundTest.java
+++ b/squidlib-util/src/test/java/squidpony/examples/SoundTest.java
@@ -25,14 +25,14 @@ public class SoundTest {
 
             System.out.println(dg);
 
-            HashSet<Coord> dudes = new HashSet<Coord>(5);
+            HashSet<Coord> dudes = new HashSet<>(5);
             dudes.add(dg.utility.randomFloor(dun));
             dudes.add(dg.utility.randomFloor(dun));
             dudes.add(dg.utility.randomFloor(dun));
             dudes.add(dg.utility.randomFloor(dun));
             dudes.add(dg.utility.randomFloor(dun));
 
-            HashMap<Coord, Double> noises = new HashMap<Coord, Double>(8);
+            HashMap<Coord, Double> noises = new HashMap<>(8);
             for(int i = 0; i < 6; i++)
             {
                 noises.put(dg.utility.randomStep(dun, dg.utility.randomFloor(dun),

--- a/squidlib-util/src/test/java/squidpony/examples/SpillTest.java
+++ b/squidlib-util/src/test/java/squidpony/examples/SpillTest.java
@@ -33,7 +33,7 @@ public class SpillTest {
             System.out.println(dg);
 
             Coord entry = dg.utility.randomFloor(dun);
-            HashSet<Coord> impassable = new HashSet<Coord>();
+            HashSet<Coord> impassable = new HashSet<>();
             impassable.add(Coord.get(entry.x + 2, entry.y));
             impassable.add(Coord.get(entry.x - 2, entry.y));
             impassable.add(Coord.get(entry.x, entry.y + 2));
@@ -69,7 +69,7 @@ public class SpillTest {
             System.out.println(dg);
             short[] valid = CoordPacker.pack(dun, '.');
 
-            LinkedHashMap<Coord, Double> entries = new LinkedHashMap<Coord, Double>(16);
+            LinkedHashMap<Coord, Double> entries = new LinkedHashMap<>(16);
             ArrayList<Coord> section = CoordPacker.randomPortion(valid, 16, rng);
             for (int i = 0; i < 4; i++) {
                 entries.put(section.get(i * 4    ), 1.0);

--- a/squidlib-util/src/test/java/squidpony/performance/AbstractPerformanceTest.java
+++ b/squidlib-util/src/test/java/squidpony/performance/AbstractPerformanceTest.java
@@ -25,7 +25,7 @@ abstract class AbstractPerformanceTest {
 	protected static final int NUM_THREADS = 1;
 	protected static final int NUM_TASKS = 1;
 
-	protected final List<AbstractPerformanceUnit> tasks = new ArrayList<AbstractPerformanceUnit>();
+	protected final List<AbstractPerformanceUnit> tasks = new ArrayList<>();
 
 	/**
 	 * this methods should be implemented by children to create one single unit

--- a/squidlib-util/src/test/java/squidpony/squidmath/CoordPackerTest.java
+++ b/squidlib-util/src/test/java/squidpony/squidmath/CoordPackerTest.java
@@ -518,7 +518,7 @@ public class CoordPackerTest {
             short[][] packed;
             int ramPacked = 0, ramFloat = 0, ramDouble = 0;
             Coord viewer;
-            HashSet<Double> seenValues = new HashSet<Double>(FOV_RANGE * 2);
+            HashSet<Double> seenValues = new HashSet<>(FOV_RANGE * 2);
             /*
             System.out.println("Packing levels at range " + FOV_RANGE + ": ");
             for (Double d : packingLevels) {
@@ -650,7 +650,7 @@ public class CoordPackerTest {
             short[][] packed;
             int ramPacked = 0, ramFloat = 0, ramDouble = 0;
             Coord viewer;
-            HashSet<Double> seenValues = new HashSet<Double>(FOV_RANGE * 2);
+            HashSet<Double> seenValues = new HashSet<>(FOV_RANGE * 2);
             /*
             System.out.println("Packing levels at range " + FOV_RANGE + ": ");
             for (Double d : packingLevels) {

--- a/squidlib/src/main/java/squidpony/squidgrid/gui/gdx/AbstractSquidScreen.java
+++ b/squidlib/src/main/java/squidpony/squidgrid/gui/gdx/AbstractSquidScreen.java
@@ -175,7 +175,7 @@ public abstract class AbstractSquidScreen<T extends Color> extends ScreenAdapter
 	 *         from {@code this}'s content.
 	 */
 	public SquidScreenInput<T> toSquidScreenInput() {
-		return new SquidScreenInput<T>(sizeManager, colorCenter, ipb);
+		return new SquidScreenInput<>(sizeManager, colorCenter, ipb);
 	}
 
 	/**

--- a/squidlib/src/main/java/squidpony/squidgrid/gui/gdx/AbstractTextScreen.java
+++ b/squidlib/src/main/java/squidpony/squidgrid/gui/gdx/AbstractTextScreen.java
@@ -86,7 +86,7 @@ public abstract class AbstractTextScreen<T extends Color> extends AbstractSquidS
 			throw new IllegalStateException("Cannot wrap an unitialized " + getClass().getSimpleName());
 
 		final List<IColoredString<T>> tsave = text;
-		text = new ArrayList<IColoredString<T>>(tsave.size() * 2);
+		text = new ArrayList<>(tsave.size() * 2);
 		final int[] asave = alignment;
 		final /* @Nullable */ List<Integer> newAlignments = asave == null ? null
 				: new ArrayList<Integer>(asave.length * 2);

--- a/squidlib/src/main/java/squidpony/squidgrid/gui/gdx/ButtonsPanel.java
+++ b/squidlib/src/main/java/squidpony/squidgrid/gui/gdx/ButtonsPanel.java
@@ -307,7 +307,7 @@ public abstract class ButtonsPanel<T extends Color> extends GroupCombinedPanel<T
 	public ButtonsPanel(ISquidPanel<T> bg, ISquidPanel<T> fg, List<IColoredString<T>> buttonTexts) {
 		super(bg, fg);
 		if (buttonTexts != null) {
-			this.buttonsTexts = new ArrayList<IColoredString<T>>(buttonTexts.size());
+			this.buttonsTexts = new ArrayList<>(buttonTexts.size());
 			this.buttonsTexts.addAll(buttonTexts);
 		}
 	}
@@ -325,7 +325,7 @@ public abstract class ButtonsPanel<T extends Color> extends GroupCombinedPanel<T
 	 */
 	public ButtonsPanel(/* Nullable */ List<IColoredString<T>> buttonTexts) {
 		if (buttonTexts != null) {
-			this.buttonsTexts = new ArrayList<IColoredString<T>>(buttonTexts.size());
+			this.buttonsTexts = new ArrayList<>(buttonTexts.size());
 			this.buttonsTexts.addAll(buttonTexts);
 		}
 	}
@@ -338,7 +338,7 @@ public abstract class ButtonsPanel<T extends Color> extends GroupCombinedPanel<T
 	 * @return {@code this}
 	 */
 	public ButtonsPanel<T> init(List<IColoredString<T>> buttonTexts) {
-		this.buttonsTexts = new ArrayList<IColoredString<T>>(buttonTexts);
+		this.buttonsTexts = new ArrayList<>(buttonTexts);
 		return this;
 	}
 
@@ -432,7 +432,7 @@ public abstract class ButtonsPanel<T extends Color> extends GroupCombinedPanel<T
 			throw new NullPointerException(
 					"The text of buttons must be set before displaying a " + getClass().getSimpleName());
 
-		this.buttons = new ArrayList<Rectangle>(buttonsTexts.size());
+		this.buttons = new ArrayList<>(buttonsTexts.size());
 
 		return putAll0(addListener, putBordersAndMargins, 0, false);
 	}
@@ -852,7 +852,7 @@ public abstract class ButtonsPanel<T extends Color> extends GroupCombinedPanel<T
 		/* @Nullable */ Character prevShortcut = null;
 
 		if (shortcuts == null)
-			shortcuts = new HashMap<Character, Integer>();
+			shortcuts = new HashMap<>();
 		else {
 			for (Map.Entry<Character, Integer> entry : shortcuts.entrySet()) {
 				if (entry.getValue() == buttonIndex) {
@@ -863,7 +863,7 @@ public abstract class ButtonsPanel<T extends Color> extends GroupCombinedPanel<T
 			}
 		}
 
-		final IColoredString<T> result = new IColoredString.Impl<T>();
+		final IColoredString<T> result = new IColoredString.Impl<>();
 		boolean set = false;
 		for (IColoredString.Bucket<T> bucket : text) {
 			final String bucketText = bucket.getText();

--- a/squidlib/src/main/java/squidpony/squidgrid/gui/gdx/SquidLayers.java
+++ b/squidlib/src/main/java/squidpony/squidgrid/gui/gdx/SquidLayers.java
@@ -295,7 +295,7 @@ public class SquidLayers extends Group {
 
         animationDuration = foregroundPanel.DEFAULT_ANIMATION_DURATION;
 
-        extraPanels = new ArrayList<SquidPanel>();
+        extraPanels = new ArrayList<>();
 
         addActorAt(0, backgroundPanel);
         addActorAt(2, foregroundPanel);
@@ -374,7 +374,7 @@ public class SquidLayers extends Group {
 
         animationDuration = foregroundPanel.DEFAULT_ANIMATION_DURATION;
 
-        extraPanels = new ArrayList<SquidPanel>();
+        extraPanels = new ArrayList<>();
 
         addActorAt(0, backgroundPanel);
         addActorAt(2, foregroundPanel);

--- a/squidlib/src/main/java/squidpony/squidgrid/gui/gdx/SquidMessageBox.java
+++ b/squidlib/src/main/java/squidpony/squidgrid/gui/gdx/SquidMessageBox.java
@@ -21,8 +21,8 @@ import java.util.List;
  * Created by Tommy Ettinger on 12/10/2015.
  */
 public class SquidMessageBox extends SquidPanel {
-    protected ArrayList<IColoredString<Color>> messages = new ArrayList<IColoredString<Color>>(256);
-    protected ArrayList<Label> labels = new ArrayList<Label>(256);
+    protected ArrayList<IColoredString<Color>> messages = new ArrayList<>(256);
+    protected ArrayList<Label> labels = new ArrayList<>(256);
     protected int messageIndex = 0;
     //private static Pattern lineWrapper;
     protected GDXMarkup markup = new GDXMarkup();
@@ -132,7 +132,7 @@ public class SquidMessageBox extends SquidPanel {
      */
     public void appendMessage(String message)
     {
-        IColoredString.Impl<Color> truncated = new IColoredString.Impl<Color>(message, defaultForeground);
+        IColoredString.Impl<Color> truncated = new IColoredString.Impl<>(message, defaultForeground);
         truncated.setLength(gridWidth - 2);
         messages.add(truncated);
         messageIndex = messages.size() - 1;
@@ -149,7 +149,7 @@ public class SquidMessageBox extends SquidPanel {
             appendMessage(message);
             return;
         }
-        List<IColoredString<Color>> truncated = new IColoredString.Impl<Color>(message, defaultForeground).wrap(gridWidth - 2);;
+        List<IColoredString<Color>> truncated = new IColoredString.Impl<>(message, defaultForeground).wrap(gridWidth - 2);;
         for (IColoredString<Color> t : truncated)
         {
             appendMessage(t.present());
@@ -164,7 +164,7 @@ public class SquidMessageBox extends SquidPanel {
      */
     public void appendMessage(IColoredString<Color> message)
     {
-        IColoredString.Impl<Color> truncated = new IColoredString.Impl<Color>();
+        IColoredString.Impl<Color> truncated = new IColoredString.Impl<>();
         truncated.append(message);
         truncated.setLength(gridWidth - 2);
         messageIndex = messages.size() - 1;

--- a/squidlib/src/main/java/squidpony/squidgrid/gui/gdx/SquidPanel.java
+++ b/squidlib/src/main/java/squidpony/squidgrid/gui/gdx/SquidPanel.java
@@ -125,7 +125,7 @@ public class SquidPanel extends Group implements ISquidPanel<Color> {
         int w = gridWidth * cellWidth;
         int h = gridHeight * cellHeight;
         setSize(w, h);
-        animatedEntities = new LinkedHashSet<AnimatedEntity>();
+        animatedEntities = new LinkedHashSet<>();
         if(factory.isDistanceField())
         {
             distanceField = true;

--- a/squidlib/src/main/java/squidpony/squidgrid/gui/gdx/TextCellFactory.java
+++ b/squidlib/src/main/java/squidpony/squidgrid/gui/gdx/TextCellFactory.java
@@ -199,7 +199,7 @@ public class TextCellFactory implements Disposable {
                 bmpFont = DefaultResources.getDefaultFont();
         }
         else {
-            assetManager.load(new AssetDescriptor<BitmapFont>(fontpath, BitmapFont.class));
+            assetManager.load(new AssetDescriptor<>(fontpath, BitmapFont.class));
 			/*
 			 * We're using the AssetManager not be asynchronous, but to avoid
 			 * loading a file twice (because that takes some time (tens of

--- a/squidlib/src/main/java/squidpony/squidgrid/gui/gdx/TextPanel.java
+++ b/squidlib/src/main/java/squidpony/squidgrid/gui/gdx/TextPanel.java
@@ -89,7 +89,7 @@ public abstract class TextPanel<T extends Color> extends GroupCombinedPanel<T> {
 	 * @param text
 	 */
 	public void init(List<IColoredString<T>> text) {
-		this.text = new ArrayList<IColoredString<T>>(text);
+		this.text = new ArrayList<>(text);
 
 		prepare();
 	}
@@ -156,7 +156,7 @@ public abstract class TextPanel<T extends Color> extends GroupCombinedPanel<T> {
 			final int w_ = computeRequiredWidth();
 			if (maxWidth < w_) {
 				/* Wrapping needed */
-				final List<IColoredString<T>> wrapped = new ArrayList<IColoredString<T>>(text.size() * 2);
+				final List<IColoredString<T>> wrapped = new ArrayList<>(text.size() * 2);
 				for (IColoredString<T> t : text) {
 					final List<IColoredString<T>> wrap = t.wrap(maxWidth);
 					for (IColoredString<T> ics : wrap)
@@ -177,7 +177,7 @@ public abstract class TextPanel<T extends Color> extends GroupCombinedPanel<T> {
 			w = bg.gridWidth();
 			h = bg.gridHeight();
 			if (justifyText) {
-				final List<IColoredString<T>> adjusted = new ArrayList<IColoredString<T>>(text.size());
+				final List<IColoredString<T>> adjusted = new ArrayList<>(text.size());
 				for (IColoredString<T> t : text)
 					adjusted.add(t.justify(w));
 				text = adjusted;

--- a/squidlib/src/main/java/squidpony/squidgrid/gui/gdx/TextScreen.java
+++ b/squidlib/src/main/java/squidpony/squidgrid/gui/gdx/TextScreen.java
@@ -42,7 +42,7 @@ public abstract class TextScreen extends AbstractTextScreen<Color> {
 			/* Job done already */
 			return;
 
-		gcp = new GroupCombinedPanel<Color>(buildScreenWideSquidPanel(), buildScreenWideSquidPanel());
+		gcp = new GroupCombinedPanel<>(buildScreenWideSquidPanel(), buildScreenWideSquidPanel());
 
 		final int width = gcp.getGridWidth();
 		final int height = gcp.getGridHeight();

--- a/squidlib/src/test/java/squidpony/gdx/examples/BasicDemo.java
+++ b/squidlib/src/test/java/squidpony/gdx/examples/BasicDemo.java
@@ -104,8 +104,8 @@ public class BasicDemo extends ApplicationAdapter {
         //creatures, and possibly a subclass for the player.
         player = dungeonGen.utility.randomCell(placement);
         //This is used to allow clicks or taps to take the player to the desired area.
-        toCursor = new ArrayList<Coord>(100);
-        awaitedMoves = new ArrayList<Coord>(100);
+        toCursor = new ArrayList<>(100);
+        awaitedMoves = new ArrayList<>(100);
         //DijkstraMap is the pathfinding swiss-army knife we use here to find a path to the latest cursor position.
         playerToCursor = new DijkstraMap(decoDungeon, DijkstraMap.Measurement.MANHATTAN);
         bgColor = SColor.DARK_SLATE_GRAY;

--- a/squidlib/src/test/java/squidpony/gdx/examples/CoveredPathDemo.java
+++ b/squidlib/src/test/java/squidpony/gdx/examples/CoveredPathDemo.java
@@ -37,7 +37,7 @@ public class CoveredPathDemo extends ApplicationAdapter {
             entity = ae;
             health = hp;
             dijkstra = dijkstraMap;
-            previousPositions = new ArrayList<Coord>(16);
+            previousPositions = new ArrayList<>(16);
         }
     }
     SpriteBatch batch;
@@ -100,14 +100,14 @@ public class CoveredPathDemo extends ApplicationAdapter {
         // it's more efficient to get random floors from a packed set containing only (compressed) floor positions.
         short[] placement = CoordPacker.pack(bareDungeon, '.');
 
-        teamRed = new ArrayList<Creature>(numMonsters);
-        teamBlue = new ArrayList<Creature>(numMonsters);
+        teamRed = new ArrayList<>(numMonsters);
+        teamBlue = new ArrayList<>(numMonsters);
 
-        redPlaces = new LinkedHashSet<Coord>(numMonsters);
-        bluePlaces = new LinkedHashSet<Coord>(numMonsters);
+        redPlaces = new LinkedHashSet<>(numMonsters);
+        bluePlaces = new LinkedHashSet<>(numMonsters);
 
-        redThreats = new ArrayList<Threat>(numMonsters);
-        blueThreats = new ArrayList<Threat>(numMonsters);
+        redThreats = new ArrayList<>(numMonsters);
+        blueThreats = new ArrayList<>(numMonsters);
         for(int i = 0; i < numMonsters; i++)
         {
             Coord monPos = dungeonGen.utility.randomCell(placement);
@@ -133,7 +133,7 @@ public class CoveredPathDemo extends ApplicationAdapter {
         getToBlue = new DijkstraMap(bareDungeon, DijkstraMap.Measurement.MANHATTAN);
         getToBlue.rng = rng;
 
-        awaitedMoves = new ArrayList<Coord>(10);
+        awaitedMoves = new ArrayList<>(10);
         colors = DungeonUtility.generatePaletteIndices(decoDungeon);
         bgColors = DungeonUtility.generateBGPaletteIndices(decoDungeon);
         lights = DungeonUtility.generateLightnessModifiers(decoDungeon, frames);
@@ -238,7 +238,7 @@ public class CoveredPathDemo extends ApplicationAdapter {
         }*/
         if(path.isEmpty())
             path.add(user);
-        awaitedMoves = new ArrayList<Coord>(path);
+        awaitedMoves = new ArrayList<>(path);
     }
 
     public void move(AnimatedEntity ae, int newX, int newY) {
@@ -266,7 +266,7 @@ public class CoveredPathDemo extends ApplicationAdapter {
 
     private LinkedHashMap<Integer, Threat> convertThreats(List<Threat> ts)
     {
-        LinkedHashMap<Integer, Threat> numbered = new LinkedHashMap<Integer, Threat>();
+        LinkedHashMap<Integer, Threat> numbered = new LinkedHashMap<>();
         int i = 0;
         for (Threat t : ts)
         {

--- a/squidlib/src/test/java/squidpony/gdx/examples/EverythingDemo.java
+++ b/squidlib/src/test/java/squidpony/gdx/examples/EverythingDemo.java
@@ -207,7 +207,7 @@ public class EverythingDemo extends ApplicationAdapter {
         Coord pl = dungeonGen.utility.randomCell(placement);
         placement = CoordPacker.removePacked(placement, pl.x, pl.y);
         int numMonsters = 25;
-        monsters = new SpatialMap<Integer, Monster>(numMonsters);
+        monsters = new SpatialMap<>(numMonsters);
         for(int i = 0; i < numMonsters; i++)
         {
             Coord monPos = dungeonGen.utility.randomCell(placement);
@@ -227,8 +227,8 @@ public class EverythingDemo extends ApplicationAdapter {
         player = display.animateActor(pl.x, pl.y, Character.forDigit(health, 10),
                 fgCenter.filter(display.getPalette().get(30)));
         cursor = Coord.get(-1, -1);
-        toCursor = new ArrayList<Coord>(10);
-        awaitedMoves = new ArrayList<Coord>(10);
+        toCursor = new ArrayList<>(10);
+        awaitedMoves = new ArrayList<>(10);
         playerToCursor = new DijkstraMap(decoDungeon, DijkstraMap.Measurement.EUCLIDEAN);
         final int[][] initialColors = DungeonUtility.generatePaletteIndices(decoDungeon),
                 initialBGColors = DungeonUtility.generateBGPaletteIndices(decoDungeon);
@@ -468,7 +468,7 @@ public class EverythingDemo extends ApplicationAdapter {
         // recalculate FOV, store it in fovmap for the render to use.
         fovmap = fov.calculateFOV(res, player.gridX, player.gridY, 8, Radius.SQUARE);
         // handle monster turns
-        ArrayList<Coord> nextMovePositions = new ArrayList<Coord>(25);
+        ArrayList<Coord> nextMovePositions = new ArrayList<>(25);
         for(Coord pos : monsters.positions())
         {
             Monster mon = monsters.get(pos);
@@ -539,7 +539,7 @@ public class EverythingDemo extends ApplicationAdapter {
         final int nbMonsters = monsters.size();
 
 		/* Prepare the String to display */
-		final IColoredString<Color> cs = new IColoredString.Impl<Color>();
+		final IColoredString<Color> cs = new IColoredString.Impl<>();
 		cs.append("Still ", null);
         final Color nbColor;
         if (nbMonsters <= 1)
@@ -554,9 +554,9 @@ public class EverythingDemo extends ApplicationAdapter {
         cs.appendInt(nbMonsters, nbColor);
         cs.append(String.format(" monster%s to kill", nbMonsters == 1 ? "" : "s"), null);
 
-        IColoredString<Color> helping1 = new IColoredString.Impl<Color>("Use numpad or vi-keys (hjklyubn) to move.", Color.WHITE);
-        IColoredString<Color> helping2 = new IColoredString.Impl<Color>("Use ? for help, f to change colors, q to quit.", Color.WHITE);
-        IColoredString<Color> helping3 = new IColoredString.Impl<Color>("Click the top or bottom border of the lower message box to scroll.", Color.WHITE);
+        IColoredString<Color> helping1 = new IColoredString.Impl<>("Use numpad or vi-keys (hjklyubn) to move.", Color.WHITE);
+        IColoredString<Color> helping2 = new IColoredString.Impl<>("Use ? for help, f to change colors, q to quit.", Color.WHITE);
+        IColoredString<Color> helping3 = new IColoredString.Impl<>("Click the top or bottom border of the lower message box to scroll.", Color.WHITE);
 
         /* Some grey color */
         final Color bgColor = new Color(0.3f, 0.3f, 0.3f, 0.9f);
@@ -574,7 +574,7 @@ public class EverythingDemo extends ApplicationAdapter {
         	final int h = 5;
         	final SquidPanel bg = new SquidPanel(w, h, display.getTextFactory());
         	final SquidPanel fg = new SquidPanel(w, h, display.getTextFactory());
-        	final GroupCombinedPanel<Color> gcp = new GroupCombinedPanel<Color>();
+        	final GroupCombinedPanel<Color> gcp = new GroupCombinedPanel<>();
         	a = gcp;
         	/*
         	 * We're setting them late just for the demo, as it avoids giving 'w'
@@ -628,7 +628,7 @@ public class EverythingDemo extends ApplicationAdapter {
 			tp.borderColor = new Color(0.9f, 0.1f, 0.0f, 0.5f);
 			tp.justifyText = true;
 
-			final List<IColoredString<Color>> text = new ArrayList<IColoredString<Color>>();
+			final List<IColoredString<Color>> text = new ArrayList<>();
 			text.add(cs);
 			/* Jump line */
 			text.add(IColoredString.Impl.<Color> create());

--- a/squidlib/src/test/java/squidpony/gdx/examples/ImageDemo.java
+++ b/squidlib/src/test/java/squidpony/gdx/examples/ImageDemo.java
@@ -60,7 +60,7 @@ public class ImageDemo extends ApplicationAdapter {
         Coord pl = dungeonGen.utility.randomFloor(placement);
         placement[pl.x][pl.y] = '@';
         int numMonsters = 15;
-        creatures = new HashMap<Coord, AnimatedEntity>(numMonsters);
+        creatures = new HashMap<>(numMonsters);
         for(int i = 0; i < numMonsters; i++)
         {
             Coord monPos = dungeonGen.utility.randomFloor(placement);

--- a/squidlib/src/test/java/squidpony/gdx/examples/SquidAIDemo.java
+++ b/squidlib/src/test/java/squidpony/gdx/examples/SquidAIDemo.java
@@ -79,11 +79,11 @@ public class SquidAIDemo extends ApplicationAdapter {
         short[] placement = CoordPacker.pack(bareDungeon, '.');
 
 
-        teamRed = new LinkedHashMap<AnimatedEntity, Integer>(numMonsters);
-        teamBlue = new LinkedHashMap<AnimatedEntity, Integer>(numMonsters);
+        teamRed = new LinkedHashMap<>(numMonsters);
+        teamBlue = new LinkedHashMap<>(numMonsters);
 
-        redPlaces = new LinkedHashSet<Coord>(numMonsters);
-        bluePlaces = new LinkedHashSet<Coord>(numMonsters);
+        redPlaces = new LinkedHashSet<>(numMonsters);
+        bluePlaces = new LinkedHashSet<>(numMonsters);
         for(int i = 0; i < numMonsters; i++)
         {
             Coord monPos = dungeonGen.utility.randomCell(placement);
@@ -141,7 +141,7 @@ public class SquidAIDemo extends ApplicationAdapter {
 
         dijkstraAlert();
 
-        awaitedMoves = new ArrayList<Coord>(10);
+        awaitedMoves = new ArrayList<>(10);
         colors = DungeonUtility.generatePaletteIndices(bareDungeon);
         bgColors = DungeonUtility.generateBGPaletteIndices(bareDungeon);
         lights = DungeonUtility.generateLightnessModifiers(bareDungeon);
@@ -278,7 +278,7 @@ public class SquidAIDemo extends ApplicationAdapter {
             }
             System.out.println();
         }*/
-        awaitedMoves = new ArrayList<Coord>(path);
+        awaitedMoves = new ArrayList<>(path);
     }
 
     public void move(AnimatedEntity ae, int newX, int newY) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2293 - “ The diamond operator (""<>"") should be used ”. You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S2293
Please let me know if you have any questions.
Ayman Abdelghany.