### PR TITLE
use Java collection interfaces rather than specific implementation

### DIFF
--- a/squidlib-util/src/main/java/squidpony/MonsterGen.java
+++ b/squidlib-util/src/main/java/squidpony/MonsterGen.java
@@ -106,7 +106,7 @@ public class MonsterGen {
             wholeAdjectives = new LinkedHashSet<>();
             powerAdjectives = new LinkedHashSet<>();
             powerPhrases = new LinkedHashSet<>();
-            ArrayList<String> selfParts = new ArrayList<>();
+            List<String> selfParts = new ArrayList<>();
             int t = 0;
             for (; t < terms.length; t++) {
                 if(terms[t].equals(";"))
@@ -189,7 +189,7 @@ public class MonsterGen {
             wholeAdjectives = new LinkedHashSet<String>(whole);
             powerAdjectives = new LinkedHashSet<String>(powerAdj);
             powerPhrases = new LinkedHashSet<String>(powerPhr);
-            ArrayList<String> selfParts = new ArrayList<String>(parts);
+            List<String> selfParts = new ArrayList<String>(parts);
             this.parts.put(name, selfParts);
         }
 
@@ -206,7 +206,7 @@ public class MonsterGen {
             else
                 sb.append('a');
             int i = 0;
-            LinkedHashSet<String> allAdjectives = new LinkedHashSet<>(wholeAdjectives);
+            Set<String> allAdjectives = new LinkedHashSet<>(wholeAdjectives);
             if(unknown != null)
                 allAdjectives.addAll(unsaidAdjectives);
             allAdjectives.addAll(powerAdjectives);
@@ -289,7 +289,7 @@ public class MonsterGen {
                 sb.append('a');
             int i = 0;
 
-            LinkedHashSet<String> allAdjectives = new LinkedHashSet<>(wholeAdjectives);
+            Set<String> allAdjectives = new LinkedHashSet<>(wholeAdjectives);
             if(unknown != null)
                 allAdjectives.addAll(unsaidAdjectives);
             for(String adj : allAdjectives)

--- a/squidlib-util/src/main/java/squidpony/WeightedLetterNamegen.java
+++ b/squidlib-util/src/main/java/squidpony/WeightedLetterNamegen.java
@@ -6,6 +6,8 @@ import squidpony.squidmath.RNG;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 
@@ -256,11 +258,11 @@ public class WeightedLetterNamegen {
     private RNG rng;
     private String[] names;
     private int consonantLimit;
-    private ArrayList<Integer> sizes;
+    private List<Integer> sizes;
 
-    private TreeMap<Character, HashMap<Character, ProbabilityTable<Character>>> letters;
-    private ArrayList<Character> firstLetterSamples;
-    private ArrayList<Character> lastLetterSamples;
+    private Map<Character, HashMap<Character, ProbabilityTable<Character>>> letters;
+    private List<Character> firstLetterSamples;
+    private List<Character> lastLetterSamples;
     private DamerauLevenshteinAlgorithm dla = new DamerauLevenshteinAlgorithm(1, 1, 1, 1);
 
     /**
@@ -414,7 +416,7 @@ public class WeightedLetterNamegen {
     private char getIntermediateLetter(char letterBefore, char letterAfter) {
         if (Character.isLetter(letterBefore) && Character.isLetter(letterAfter)) {
             // First grab all letters that come after the 'letterBefore'
-            HashMap<Character, ProbabilityTable<Character>> wl = letters.get(letterBefore);
+            Map<Character, ProbabilityTable<Character>> wl = letters.get(letterBefore);
             if (wl == null) {
                 return getRandomNextLetter(letterBefore);
             }

--- a/squidlib-util/src/main/java/squidpony/panel/IColoredString.java
+++ b/squidlib-util/src/main/java/squidpony/panel/IColoredString.java
@@ -139,7 +139,7 @@ public interface IColoredString<T> extends Iterable<IColoredString.Bucket<T>> {
 	 */
 	class Impl<T> implements IColoredString<T> {
 
-		protected final LinkedList<Bucket<T>> fragments;
+		protected final AbstractList<Bucket<T>> fragments;
 
 		/**
 		 * An empty instance.

--- a/squidlib-util/src/main/java/squidpony/squidai/DijkstraMap.java
+++ b/squidlib-util/src/main/java/squidpony/squidai/DijkstraMap.java
@@ -108,8 +108,8 @@ public class DijkstraMap {
      * Goals that pathfinding will seek out. The Double value should almost always be 0.0 , the same as the static GOAL
      * constant in this class.
      */
-    public LinkedHashMap<Coord, Double> goals;
-    private LinkedHashMap<Coord, Double> fresh, closed, open;
+    public Map<Coord, Double> goals;
+    private Map<Coord, Double> fresh, closed, open;
     /**
      * The RNG used to decide which one of multiple equally-short paths to take.
      */
@@ -738,7 +738,7 @@ public class DijkstraMap {
         if (!initialized) return null;
         if (impassable == null)
             impassable = new LinkedHashSet<>();
-        LinkedHashMap<Coord, Double> blocking = new LinkedHashMap<>(impassable.size());
+        Map<Coord, Double> blocking = new LinkedHashMap<>(impassable.size());
         for (Coord pt : impassable) {
             blocking.put(pt, WALL);
         }
@@ -750,7 +750,7 @@ public class DijkstraMap {
             gradientMap[entry.getKey().x][entry.getKey().y] = entry.getValue();
         }
         double currentLowest = 999000;
-        LinkedHashMap<Coord, Double> lowest = new LinkedHashMap<>();
+        Map<Coord, Double> lowest = new LinkedHashMap<>();
 
         for (int y = 0; y < height; y++) {
             for (int x = 0; x < width; x++) {
@@ -822,7 +822,7 @@ public class DijkstraMap {
         if (!initialized) return null;
         if (impassable == null)
             impassable = new LinkedHashSet<>();
-        LinkedHashMap<Coord, Double> blocking = new LinkedHashMap<>(impassable.size());
+        Map<Coord, Double> blocking = new LinkedHashMap<>(impassable.size());
         for (Coord pt : impassable) {
             blocking.put(pt, WALL);
         }
@@ -834,7 +834,7 @@ public class DijkstraMap {
             gradientMap[entry.getKey().x][entry.getKey().y] = entry.getValue();
         }
         double currentLowest = 999000;
-        LinkedHashMap<Coord, Double> lowest = new LinkedHashMap<>();
+        Map<Coord, Double> lowest = new LinkedHashMap<>();
 
         for (int y = 0; y < height; y++) {
             for (int x = 0; x < width; x++) {
@@ -967,7 +967,7 @@ public class DijkstraMap {
      * @return the Coord that it found first.
      */
     public Coord findNearest(Coord start, Coord... targets) {
-        LinkedHashSet<Coord> tgts = new LinkedHashSet<>(targets.length);
+        Set<Coord> tgts = new LinkedHashSet<>(targets.length);
         Collections.addAll(tgts, targets);
         return findNearest(start, tgts);
     }
@@ -1116,7 +1116,7 @@ public class DijkstraMap {
         if (!initialized) return null;
         if (impassable == null)
             impassable = new LinkedHashSet<>();
-        LinkedHashMap<Coord, Double> blocking = new LinkedHashMap<>(impassable.size());
+        Map<Coord, Double> blocking = new LinkedHashMap<>(impassable.size());
         for (Coord pt : impassable) {
             blocking.put(pt, WALL);
             for (int x = 0; x < size; x++) {
@@ -1137,7 +1137,7 @@ public class DijkstraMap {
         }
         mappedCount = goals.size();
         double currentLowest = 999000;
-        LinkedHashMap<Coord, Double> lowest = new LinkedHashMap<>();
+        Map<Coord, Double> lowest = new LinkedHashMap<>();
         Coord p = Coord.get(0, 0), temp = Coord.get(0, 0);
         for (int y = 0; y < height; y++) {
             I_AM_BECOME_DEATH_DESTROYER_OF_WORLDS:
@@ -1246,7 +1246,7 @@ public class DijkstraMap {
                                      Set<Coord> onlyPassable, Coord start, Coord... targets) {
         if (!initialized) return null;
         path = new ArrayList<>();
-        LinkedHashSet<Coord> impassable2;
+        Set<Coord> impassable2;
         if (impassable == null)
             impassable2 = new LinkedHashSet<>();
         else
@@ -1370,7 +1370,7 @@ public class DijkstraMap {
             }
         }
         path = new ArrayList<>();
-        LinkedHashSet<Coord> impassable2;
+        Set<Coord> impassable2;
         if (impassable == null)
             impassable2 = new LinkedHashSet<>();
         else
@@ -1511,7 +1511,7 @@ public class DijkstraMap {
         double[][] userDistanceMap;
         double paidLength = 0.0;
 
-        LinkedHashSet<Coord> friends;
+        Set<Coord> friends;
 
 
         for (int x = 0; x < width; x++) {
@@ -1524,7 +1524,7 @@ public class DijkstraMap {
         path = new ArrayList<>();
         if (targets == null || targets.size() == 0)
             return path;
-        LinkedHashSet<Coord> impassable2;
+        Set<Coord> impassable2;
         if (impassable == null)
             impassable2 = new LinkedHashSet<>();
         else
@@ -1559,7 +1559,7 @@ public class DijkstraMap {
         clearGoals();
 
         Coord tempPt = Coord.get(0, 0);
-        LinkedHashMap<Coord, ArrayList<Coord>> ideal;
+        Map<Coord, ArrayList<Coord>> ideal;
         // generate an array of the single best location to attack when you are in a given cell.
         for (int x = 0; x < width; x++) {
             CELL:
@@ -1726,7 +1726,7 @@ public class DijkstraMap {
         if (maxPreferredRange < minPreferredRange) maxPreferredRange = minPreferredRange;
 
         path = new ArrayList<>();
-        LinkedHashSet<Coord> impassable2;
+        Set<Coord> impassable2;
         if (impassable == null)
             impassable2 = new LinkedHashSet<>();
         else
@@ -1866,7 +1866,7 @@ public class DijkstraMap {
 
 
         path = new ArrayList<Coord>();
-        LinkedHashSet<Coord> impassable2;
+        Set<Coord> impassable2;
         if (impassable == null)
             impassable2 = new LinkedHashSet<Coord>();
         else
@@ -2069,7 +2069,7 @@ public class DijkstraMap {
 
 
         path = new ArrayList<Coord>();
-        LinkedHashSet<Coord> impassable2;
+        Set<Coord> impassable2;
         if (impassable == null)
             impassable2 = new LinkedHashSet<Coord>();
         else
@@ -2292,7 +2292,7 @@ public class DijkstraMap {
         }
 
         path = new ArrayList<>();
-        LinkedHashSet<Coord> impassable2;
+        Set<Coord> impassable2;
         if (impassable == null)
             impassable2 = new LinkedHashSet<>();
         else
@@ -2473,7 +2473,7 @@ public class DijkstraMap {
         double[][] userDistanceMap = new double[width][height];
         double paidLength = 0.0;
 
-        LinkedHashSet<Coord> friends;
+        Set<Coord> friends;
 
 
         for (int x = 0; x < width; x++) {
@@ -2486,7 +2486,7 @@ public class DijkstraMap {
         path = new ArrayList<>();
         if (targets == null || targets.size() == 0)
             return path;
-        LinkedHashSet<Coord> impassable2;
+        Set<Coord> impassable2;
         if (impassable == null)
             impassable2 = new LinkedHashSet<>();
         else
@@ -2521,7 +2521,7 @@ public class DijkstraMap {
         clearGoals();
 
         Coord tempPt = Coord.get(0, 0);
-        LinkedHashMap<Coord, ArrayList<Coord>> ideal;
+        Map<Coord, ArrayList<Coord>> ideal;
         // generate an array of the single best location to attack when you are in a given cell.
         for (int x = 0; x < width; x++) {
             CELL:
@@ -2775,7 +2775,7 @@ public class DijkstraMap {
                                           Set<Coord> onlyPassable, Coord start, Coord... targets) {
         if (!initialized) return null;
         path = new ArrayList<>();
-        LinkedHashSet<Coord> impassable2;
+        Set<Coord> impassable2;
         if (impassable == null)
             impassable2 = new LinkedHashSet<>();
         else
@@ -2877,7 +2877,7 @@ public class DijkstraMap {
             }
         }
         path = new ArrayList<>();
-        LinkedHashSet<Coord> impassable2;
+        Set<Coord> impassable2;
         if (impassable == null)
             impassable2 = new LinkedHashSet<>();
         else
@@ -3012,7 +3012,7 @@ public class DijkstraMap {
             }
         }
         path = new ArrayList<>();
-        LinkedHashSet<Coord> impassable2;
+        Set<Coord> impassable2;
         if (impassable == null)
             impassable2 = new LinkedHashSet<>();
         else

--- a/squidlib-util/src/main/java/squidpony/squidai/WaypointPathfinder.java
+++ b/squidlib-util/src/main/java/squidpony/squidai/WaypointPathfinder.java
@@ -24,7 +24,7 @@ public class WaypointPathfinder {
     private char[][] map;
     private int[][] expansionMap;
     public RNG rng;
-    private LinkedHashMap<Coord, LinkedHashMap<Coord, Edge>> waypoints;
+    private Map<Coord, LinkedHashMap<Coord, Edge>> waypoints;
 
     /**
      * Calculates and stores the doors and doors-like connections ("chokepoints") on the given map as waypoints.
@@ -44,7 +44,7 @@ public class WaypointPathfinder {
         width = map.length;
         height = map[0].length;
         char[][] simplified = DungeonUtility.simplifyDungeon(map);
-        ArrayList<Coord> centers = PoissonDisk.sampleMap(simplified,
+        List<Coord> centers = PoissonDisk.sampleMap(simplified,
                 Math.min(width, height) * 0.4f, this.rng, '#');
         int centerCount = centers.size();
         expansionMap = new int[width][height];
@@ -79,7 +79,7 @@ public class WaypointPathfinder {
             }
         }
 
-        LinkedHashSet<Coord> chokes = new LinkedHashSet<>(128);
+        Set<Coord> chokes = new LinkedHashSet<>(128);
         for (int i = 0; i < width; i++) {
             ELEMENT_WISE:
             for (int j = 0; j < height; j++) {
@@ -172,7 +172,7 @@ public class WaypointPathfinder {
         char[][] simplified = DungeonUtility.simplifyDungeon(map);
         expansionMap = new int[width][height];
         waypoints = new LinkedHashMap<>(64);
-        LinkedHashSet<Coord> chokes = new LinkedHashSet<>(128);
+        Set<Coord> chokes = new LinkedHashSet<>(128);
 
         if(thickCorridors)
         {
@@ -187,7 +187,7 @@ public class WaypointPathfinder {
             }
         }
         else {
-            ArrayList<Coord> centers = PoissonDisk.sampleMap(simplified,
+            List<Coord> centers = PoissonDisk.sampleMap(simplified,
                     Math.min(width, height) * 0.4f, this.rng, '#');
             int centerCount = centers.size();
             dm = new DijkstraMap(simplified, DijkstraMap.Measurement.MANHATTAN);
@@ -293,7 +293,7 @@ public class WaypointPathfinder {
         char[][] simplified = DungeonUtility.simplifyDungeon(map);
         expansionMap = new int[width][height];
         waypoints = new LinkedHashMap<>(64);
-        LinkedHashSet<Coord> chokes = new LinkedHashSet<>(128);
+        Set<Coord> chokes = new LinkedHashSet<>(128);
 
         short[] floors = pack(simplified, '.');
         Coord[] apart = fractionPacked(floors, fraction);
@@ -341,7 +341,7 @@ public class WaypointPathfinder {
         width = map.length;
         height = map[0].length;
         char[][] simplified = DungeonUtility.simplifyDungeon(map);
-        ArrayList<Coord> centers = PoissonDisk.sampleMap(simplified,
+        List<Coord> centers = PoissonDisk.sampleMap(simplified,
                 Math.min(width, height) * 0.4f, this.rng, '#');
         int centerCount = centers.size();
         expansionMap = new int[width][height];
@@ -376,7 +376,7 @@ public class WaypointPathfinder {
             }
         }
 
-        LinkedHashSet<Coord> chokes = new LinkedHashSet<>(128);
+        Set<Coord> chokes = new LinkedHashSet<>(128);
         for (int i = 0; i < width; i++) {
             ELEMENT_WISE:
             for (int j = 0; j < height; j++) {
@@ -430,7 +430,7 @@ public class WaypointPathfinder {
      * @return an ArrayList of Coord that will go from a cell adjacent to self to a waypoint near approximateTarget
      */
     public ArrayList<Coord> getKnownPath(Coord self, Coord approximateTarget) {
-        ArrayList<Coord> near = dm.findNearestMultiple(approximateTarget, 5, waypoints.keySet());
+        Iterable<Coord> near = dm.findNearestMultiple(approximateTarget, 5, waypoints.keySet());
         Coord me = dm.findNearest(self, waypoints.keySet());
         double bestCost = 999999.0;
         ArrayList<Coord> path = new ArrayList<>();

--- a/squidlib-util/src/main/java/squidpony/squidgrid/FOVCache.java
+++ b/squidlib-util/src/main/java/squidpony/squidgrid/FOVCache.java
@@ -1849,8 +1849,8 @@ public class FOVCache extends FOV{
          */
         @Override
         public void run() {
-            ArrayList<ArrayList<LOSUnit>> losUnits = new ArrayList<>(24);
-            ArrayList<ArrayList<FOVUnit>> fovUnits = new ArrayList<>(24);
+            List<ArrayList<LOSUnit>> losUnits = new ArrayList<>(24);
+            List<ArrayList<FOVUnit>> fovUnits = new ArrayList<>(24);
             for (int p = 0; p < 24; p++) {
                 losUnits.add(new ArrayList<LOSUnit>(mapLimit / 20));
                 fovUnits.add(new ArrayList<FOVUnit>(mapLimit / 20));
@@ -1939,7 +1939,7 @@ public class FOVCache extends FOV{
                 }
             }
 
-            ArrayList<ArrayList<SymmetryUnit>> symUnits = new ArrayList<>(4);
+            List<ArrayList<SymmetryUnit>> symUnits = new ArrayList<>(4);
             for (int p = 0; p < 4; p++) {
                 symUnits.add(new ArrayList<SymmetryUnit>(mapLimit / 3));
             }

--- a/squidlib-util/src/main/java/squidpony/squidgrid/LOS.java
+++ b/squidlib-util/src/main/java/squidpony/squidgrid/LOS.java
@@ -339,7 +339,7 @@ public class LOS {
     private boolean thickReachable(Radius radiusStrategy) {
         lastPath = new LinkedList<>();
         double dist = radiusStrategy.radius(startx, starty, targetx, targety), decay = 1 / dist;
-        LinkedHashSet<Coord> visited = new LinkedHashSet<>((int) dist + 3);
+        Set<Coord> visited = new LinkedHashSet<>((int) dist + 3);
         List<List<Coord>> paths = new ArrayList<>(4);
         /* // actual corners
         paths.add(DDALine.line(startx, starty, targetx, targety, 0, 0));
@@ -387,7 +387,7 @@ public class LOS {
     private boolean brushReachable(Radius radiusStrategy, int spread) {
         lastPath = new LinkedList<>();
         double dist = radiusStrategy.radius(startx, starty, targetx, targety) + spread * 2, decay = 1 / dist;
-        LinkedHashSet<Coord> visited = new LinkedHashSet<>((int) (dist + 3) * spread);
+        Set<Coord> visited = new LinkedHashSet<>((int) (dist + 3) * spread);
         List<List<Coord>> paths = new ArrayList<>((int) (radiusStrategy.volume2D(spread) * 1.25));
         int length = 0;
         List<Coord> currentPath;
@@ -521,7 +521,7 @@ public class LOS {
         List<Coord> ePath = elias.line(startx, starty, targetx, targety);
         lastPath = new LinkedList<>(ePath);//save path for later retreival
 
-        HashMap<eliasWorker, Thread> pool = new HashMap<>();
+        Map<eliasWorker, Thread> pool = new HashMap<>();
 
         for (Coord p : ePath) {
             eliasWorker worker = new eliasWorker(p.x, p.y, radiusStrategy);

--- a/squidlib-util/src/main/java/squidpony/squidgrid/MultiSpill.java
+++ b/squidlib-util/src/main/java/squidpony/squidgrid/MultiSpill.java
@@ -9,6 +9,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -66,7 +67,7 @@ public class MultiSpill {
      * are reached on all sides and the Spill has no more room to fill.
      */
     public int filled = 0;
-    private ArrayList<LinkedHashSet<Coord>> fresh;
+    private List<LinkedHashSet<Coord>> fresh;
     /**
      * The StatefulRNG used to decide how to randomly fill a space; can have its state set and read.
      */
@@ -308,7 +309,7 @@ public class MultiSpill {
 
     protected void setFresh(int idx, final Coord pt) {
         if(!initialized) return;
-        for(LinkedHashSet<Coord> f : fresh)
+        for(Set<Coord> f : fresh)
         {
             if(f.contains(pt))
                 return;
@@ -340,7 +341,7 @@ public class MultiSpill {
             impassable = new LinkedHashSet<>();
         if(volume < 0)
             volume = Integer.MAX_VALUE;
-        ArrayList<Coord> spillers = new ArrayList<>(entries);
+        List<Coord> spillers = new ArrayList<>(entries);
         spreadPattern = new ArrayList<>(spillers.size());
         fresh.clear();
         for (short i = 0; i < spillers.size(); i++) {
@@ -416,13 +417,13 @@ public class MultiSpill {
      * @return an ArrayList of Points that this will enter, in order starting with entry at index 0, until it
      * reaches its volume or fills its boundaries completely.
      */
-    public ArrayList<ArrayList<Coord>> start(LinkedHashMap<Coord, Double> entries, int volume, Set<Coord> impassable) {
+    public ArrayList<ArrayList<Coord>> start(Map<Coord, Double> entries, int volume, Set<Coord> impassable) {
         if(!initialized) return null;
         if(impassable == null)
             impassable = new LinkedHashSet<>();
         if(volume < 0)
             volume = Integer.MAX_VALUE;
-        ArrayList<Coord> spillers0 = new ArrayList<>(entries.keySet()),
+        List<Coord> spillers0 = new ArrayList<>(entries.keySet()),
                 spillers = new ArrayList<>(spillers0.size());
         ArrayList<Double> biases0 = new ArrayList<>(entries.values()),
                 biases = new ArrayList<>(biases0.size());

--- a/squidlib-util/src/main/java/squidpony/squidgrid/Radius.java
+++ b/squidlib-util/src/main/java/squidpony/squidgrid/Radius.java
@@ -227,7 +227,7 @@ public enum Radius {
 
     public Set<Coord> perimeter(Coord center, int radiusLength, boolean surpassEdges, int width, int height)
     {
-        LinkedHashSet<Coord> rim = new LinkedHashSet<>(4 * radiusLength);
+        Set<Coord> rim = new LinkedHashSet<>(4 * radiusLength);
         if(!surpassEdges && (center.x < 0 || center.x >= width || center.y < 0 || center.y > height))
             return rim;
         if(radiusLength < 1) {

--- a/squidlib-util/src/main/java/squidpony/squidgrid/SoundMap.java
+++ b/squidlib-util/src/main/java/squidpony/squidgrid/SoundMap.java
@@ -404,7 +404,7 @@ public class SoundMap
 
         while (numAssigned > 0) {
             numAssigned = 0;
-            HashMap<Coord, Double> fresh2 = new HashMap<>(fresh.size());
+            Map<Coord, Double> fresh2 = new HashMap<>(fresh.size());
             fresh2.putAll(fresh);
             fresh.clear();
 
@@ -449,7 +449,7 @@ public class SoundMap
      * @param extraSounds
      * @return
      */
-    public HashMap<Coord, Double> findAlerted(Set<Coord> creatures, Map<Coord, Double> extraSounds) {
+    public Map<Coord, Double> findAlerted(Set<Coord> creatures, Map<Coord, Double> extraSounds) {
         if(!initialized) return null;
         alerted = new HashMap<>(creatures.size());
 

--- a/squidlib-util/src/main/java/squidpony/squidgrid/SpatialMap.java
+++ b/squidlib-util/src/main/java/squidpony/squidgrid/SpatialMap.java
@@ -56,8 +56,8 @@ public class SpatialMap<I, E> implements Iterable<E> {
         }
     }
 
-    protected LinkedHashMap<I, SpatialTriple<I, E>> itemMapping;
-    protected LinkedHashMap<Coord, SpatialTriple<I, E>> positionMapping;
+    protected Map<I, SpatialTriple<I, E>> itemMapping;
+    protected Map<Coord, SpatialTriple<I, E>> positionMapping;
 
     /**
      * Constructs a SpatialMap with capacity 32.

--- a/squidlib-util/src/main/java/squidpony/squidgrid/mapping/DividedMazeGenerator.java
+++ b/squidlib-util/src/main/java/squidpony/squidgrid/mapping/DividedMazeGenerator.java
@@ -70,7 +70,7 @@ public class DividedMazeGenerator {
         stack.offer(new DividedMazeRoom(1, 1, width - 2, height - 2));
         while (!stack.isEmpty()) {
             DividedMazeRoom room = stack.pop();
-            ArrayList<Integer> availX = new ArrayList<>(),
+            List<Integer> availX = new ArrayList<>(),
                                availY = new ArrayList<>();
 
             for (int x = room.left + 1; x < room.right; x++) {

--- a/squidlib-util/src/main/java/squidpony/squidgrid/mapping/DungeonGenerator.java
+++ b/squidlib-util/src/main/java/squidpony/squidgrid/mapping/DungeonGenerator.java
@@ -9,9 +9,12 @@ import squidpony.squidgrid.mapping.styled.TilesetType;
 import squidpony.squidmath.*;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.EnumMap;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
 
 import static squidpony.squidmath.CoordPacker.*;
 
@@ -528,7 +531,7 @@ public class DungeonGenerator {
     private char[][] innerGenerate(char[][] map)
     {
 
-        LinkedHashSet<Coord> floors = new LinkedHashSet<>();
+        Set<Coord> floors = new LinkedHashSet<>();
         LinkedHashSet<Coord> doorways;
         LinkedHashSet<Coord> hazards = new LinkedHashSet<>();
         Coord temp;
@@ -642,7 +645,7 @@ public class DungeonGenerator {
 
         MultiSpill ms = new MultiSpill(map, Spill.Measurement.MANHATTAN, rng);
         LinkedHashMap<Coord, Double> fillers = new LinkedHashMap<>(128);
-        ArrayList<Coord> dots = PoissonDisk.sampleMap(map, Math.min(width, height) / 8f, rng, '#', '+', '/','<', '>');
+        List<Coord> dots = PoissonDisk.sampleMap(map, Math.min(width, height) / 8f, rng, '#', '+', '/','<', '>');
         for (int i = 0; i < dots.size(); i++) {
             switch (i % 3) {
                 case 0:
@@ -657,10 +660,10 @@ public class DungeonGenerator {
             }
         }
 
-        ArrayList<ArrayList<Coord>> fills = ms.start(fillers, -1, null);
+        Iterable<ArrayList<Coord>> fills = ms.start(fillers, -1, null);
 
         int ctr = 0;
-        for(ArrayList<Coord> pts : fills)
+        for(Collection<Coord> pts : fills)
         {
             switch (ctr % 3) {
                 case 0:
@@ -687,7 +690,7 @@ public class DungeonGenerator {
                         }
                     }
                     if(islandSpacing > 1) {
-                        ArrayList<Coord> islands = PoissonDisk.sampleMap(map, 1f * islandSpacing, rng, '#', '.', '"', '+', '/', '^', '<', '>');
+                        Iterable<Coord> islands = PoissonDisk.sampleMap(map, 1f * islandSpacing, rng, '#', '.', '"', '+', '/', '^', '<', '>');
                         for (Coord c : islands) {
                             map[c.x][c.y] = '.';
                             if (map[c.x - 1][c.y] != '#' && map[c.x - 1][c.y] != '<' && map[c.x - 1][c.y] != '>')
@@ -861,7 +864,7 @@ public class DungeonGenerator {
                 Coord entry = floors.toArray(new Coord[floors.size()])[rng.nextInt(floors.size())];
                 spill.start(entry, volumes[i] / 3, obstacles);
                 spill.start(entry, 2 * volumes[i] / 3, obstacles);
-                ArrayList<Coord> ordered = new ArrayList<>(spill.start(entry, volumes[i], obstacles));
+                Collection<Coord> ordered = new ArrayList<>(spill.start(entry, volumes[i], obstacles));
                 floors.removeAll(ordered);
                 hazards.removeAll(ordered);
                 obstacles.addAll(ordered);
@@ -882,7 +885,7 @@ public class DungeonGenerator {
             while (bonusVolume > 0 && frustration < 50)
             {
                 Coord entry = utility.randomFloor(map);
-                ArrayList<Coord> finisher = spill.start(entry, bonusVolume, obstacles);
+                Collection<Coord> finisher = spill.start(entry, bonusVolume, obstacles);
                 for(Coord p : finisher)
                 {
                     map[p.x][p.y] = '"';
@@ -918,7 +921,7 @@ public class DungeonGenerator {
                 Coord entry = floors.toArray(new Coord[floors.size()])[rng.nextInt(floors.size())];
 //                spill.start(entry, volumes[i] / 3, obstacles);
 //                spill.start(entry, 2 * volumes[i] / 3, obstacles);
-                ArrayList<Coord> ordered = new ArrayList<>(spill.start(entry, volumes[i], obstacles));
+                Collection<Coord> ordered = new ArrayList<>(spill.start(entry, volumes[i], obstacles));
                 floors.removeAll(ordered);
                 hazards.removeAll(ordered);
                 obstacles.addAll(ordered);
@@ -940,7 +943,7 @@ public class DungeonGenerator {
             while (bonusVolume > 0 && frustration < 50)
             {
                 Coord entry = utility.randomFloor(map);
-                ArrayList<Coord> finisher = spill.start(entry, bonusVolume, obstacles);
+                Collection<Coord> finisher = spill.start(entry, bonusVolume, obstacles);
                 for(Coord p : finisher)
                 {
                     map[p.x][p.y] = '~';
@@ -959,7 +962,7 @@ public class DungeonGenerator {
                 }
             }
             if(islandSpacing > 1) {
-                ArrayList<Coord> islands = PoissonDisk.sampleMap(map, 1f * islandSpacing, rng, '#', '.', '"', '+', '/', '^');
+                Iterable<Coord> islands = PoissonDisk.sampleMap(map, 1f * islandSpacing, rng, '#', '.', '"', '+', '/', '^');
                 for (Coord c : islands) {
                     map[c.x][c.y] = '.';
                     if (map[c.x - 1][c.y] != '#')

--- a/squidlib-util/src/main/java/squidpony/squidgrid/mapping/GrowingTreeMazeGenerator.java
+++ b/squidlib-util/src/main/java/squidpony/squidgrid/mapping/GrowingTreeMazeGenerator.java
@@ -7,6 +7,7 @@ import squidpony.squidmath.Coord;
 import squidpony.squidmath.RNG;
 
 import java.util.ArrayList;
+import java.util.List;
 
 /**
  *
@@ -41,7 +42,7 @@ public class GrowingTreeMazeGenerator {
         x *= 2;
         y *= 2;
 
-        ArrayList<Coord> deck = new ArrayList<>();
+        List<Coord> deck = new ArrayList<>();
         deck.add(Coord.get(x, y));
 
         Direction[] dirs = Direction.CARDINALS;

--- a/squidlib-util/src/main/java/squidpony/squidgrid/mapping/MixedGenerator.java
+++ b/squidlib-util/src/main/java/squidpony/squidgrid/mapping/MixedGenerator.java
@@ -128,7 +128,7 @@ public class MixedGenerator {
      * @param roomSizeMultiplier a float multiplier that will be applied to each room's width and height
      * @see SerpentMapGenerator a class that uses this technique
      */
-    public MixedGenerator(int width, int height, RNG rng, LinkedHashMap<Coord, List<Coord>> connections,
+    public MixedGenerator(int width, int height, RNG rng, Map<Coord, List<Coord>> connections,
                           float roomSizeMultiplier) {
         this.width = width;
         this.height = height;

--- a/squidlib-util/src/main/java/squidpony/squidgrid/mapping/RoomFinder.java
+++ b/squidlib-util/src/main/java/squidpony/squidgrid/mapping/RoomFinder.java
@@ -176,7 +176,7 @@ public class RoomFinder {
         else
         {
             found = regions.get(0);
-            ArrayList<List<short[]>> near = rooms.allAt(x, y);
+            Iterable<List<short[]>> near = rooms.allAt(x, y);
             for (List<short[]> links : near) {
                 for(short[] n : links)
                 {
@@ -204,7 +204,7 @@ public class RoomFinder {
     public ArrayList<char[][]> regionsConnected(int x, int y)
     {
         ArrayList<char[][]> regions = new ArrayList<char[][]>(10);
-        ArrayList<List<short[]>> near = rooms.allAt(x, y);
+        Iterable<List<short[]>> near = rooms.allAt(x, y);
         for (List<short[]> links : near) {
             for(short[] n : links)
             {

--- a/squidlib-util/src/main/java/squidpony/squidgrid/mapping/SerpentDeepMapGenerator.java
+++ b/squidlib-util/src/main/java/squidpony/squidgrid/mapping/SerpentDeepMapGenerator.java
@@ -5,9 +5,11 @@ import squidpony.squidmath.CoordPacker;
 import squidpony.squidmath.RNG;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Generate dungeons based on a random, winding, looping path through 3D space, requiring a character to move up and
@@ -24,7 +26,7 @@ public class SerpentDeepMapGenerator {
     private MixedGenerator[] mix;
     private int[] columns, rows;
     private int width, height, depth;
-    private ArrayList<LinkedHashSet<Coord>> linksUp,linksDown;
+    private List<LinkedHashSet<Coord>> linksUp,linksDown;
     private RNG random;
 
     /**
@@ -340,7 +342,7 @@ public class SerpentDeepMapGenerator {
             floors[i] = CoordPacker.pack(dungeon[i], '.');
         }
         //using actual dungeon space per layer, not row/column 3D grid space
-        ArrayList<LinkedHashSet<Coord>> ups = new ArrayList<>(depth),
+        List<LinkedHashSet<Coord>> ups = new ArrayList<>(depth),
                 downs = new ArrayList<>(depth);
         for (int i = 0; i < depth; i++) {
             ups.add(new LinkedHashSet<Coord>(40));
@@ -359,7 +361,7 @@ public class SerpentDeepMapGenerator {
                     short[] near = CoordPacker.intersectPacked(nearAbove, CoordPacker.flood(floors[i],
                             CoordPacker.packOne(columns[higher.x], rows[higher.y]),
                             dlimit));
-                    ArrayList<Coord> subLinks = CoordPacker.randomPortion(near, 1, random);
+                    Collection<Coord> subLinks = CoordPacker.randomPortion(near, 1, random);
                     ups.get(i).addAll(subLinks);
                     downs.get(i-1).addAll(subLinks);
                     for(Coord abv : linksDown.get(i-1))
@@ -375,7 +377,7 @@ public class SerpentDeepMapGenerator {
         }
 
         for (int i = 0; i < depth; i++) {
-            LinkedHashMap<Coord, Integer> used = new LinkedHashMap<>(128);
+            Map<Coord, Integer> used = new LinkedHashMap<>(128);
             for(Coord up : ups.get(i))
             {
                 Integer count = used.get(up);

--- a/squidlib-util/src/main/java/squidpony/squidgrid/mapping/SymmetryDungeonGenerator.java
+++ b/squidlib-util/src/main/java/squidpony/squidgrid/mapping/SymmetryDungeonGenerator.java
@@ -25,7 +25,7 @@ public class SymmetryDungeonGenerator extends MixedGenerator {
         }
         return listToMap(s2);
     }
-    public static LinkedHashMap<Coord, List<Coord>> removeSomeOverlap(int width, int height, LinkedHashMap<Coord, List<Coord>> connections) {
+    public static LinkedHashMap<Coord, List<Coord>> removeSomeOverlap(int width, int height, Map<Coord, List<Coord>> connections) {
         LinkedHashMap<Coord, List<Coord>> lhm2 = new LinkedHashMap<>(connections.size());
         Set<Coord> keyset = connections.keySet(), newkeys = new LinkedHashSet<>(connections.size());
         for (Coord c : keyset) {
@@ -135,7 +135,7 @@ public class SymmetryDungeonGenerator extends MixedGenerator {
         return conns;
     }
 
-    protected static LinkedHashMap<Coord, List<Coord>> crossConnect(int width, int height, LinkedHashMap<Coord, List<Coord>> connections)
+    protected static LinkedHashMap<Coord, List<Coord>> crossConnect(int width, int height, Map<Coord, List<Coord>> connections)
     {
         LinkedHashMap<Coord, List<Coord>> conns = new LinkedHashMap<>(connections.size());
         for(Map.Entry<Coord, List<Coord>> entry : connections.entrySet())

--- a/squidlib-util/src/main/java/squidpony/squidmath/AStarSearch.java
+++ b/squidlib-util/src/main/java/squidpony/squidmath/AStarSearch.java
@@ -3,9 +3,11 @@ package squidpony.squidmath;
 
 import squidpony.squidgrid.Direction;
 
+import java.util.Deque;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.Queue;
+import java.util.Set;
 
 /**
  * Performs A* search.
@@ -45,7 +47,7 @@ public class AStarSearch {
     }
 
     private final double[][] map;
-    private final HashSet<Coord> open = new HashSet<>();
+    private final Set<Coord> open = new HashSet<>();
     private final int width, height;
     private boolean[][] finished;
     private Coord[][] parent;
@@ -154,7 +156,7 @@ public class AStarSearch {
         }
 
         /* Not using Deque nor ArrayDeqye, they aren't Gwt compatible */
-        final LinkedList<Coord> deq = new LinkedList<>();
+        final Deque<Coord> deq = new LinkedList<>();
         while (!p.equals(start)) {
             deq.addFirst(p);
             p = parent[p.x][p.y];

--- a/squidlib-util/src/main/java/squidpony/squidmath/CoordPacker.java
+++ b/squidlib-util/src/main/java/squidpony/squidmath/CoordPacker.java
@@ -8,6 +8,7 @@ import squidpony.squidgrid.Radius;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 
 
 /**
@@ -1264,7 +1265,7 @@ public class CoordPacker {
      *               returned by packMulti(); null elements in packed will be skipped.
      * @return an ArrayList of all packed arrays that store true at the given x,y location.
      */
-    public static ArrayList<short[]> findManyPackedHilbert(short hilbert, short[] ... packed)
+    public static Collection<short[]> findManyPackedHilbert(short hilbert, short[] ... packed)
     {
         ArrayList<short[]> packs = new ArrayList<>(packed.length);
         int hilbertDistance = hilbert & 0xffff;

--- a/squidlib-util/src/main/java/squidpony/squidmath/Dice.java
+++ b/squidlib-util/src/main/java/squidpony/squidmath/Dice.java
@@ -51,7 +51,7 @@ public class Dice {
      */
     public int bestOf(int n, int dice, int sides) {
         int rolls = Math.min(n, dice);
-        ArrayList<Integer> results = new ArrayList<>(dice);
+        List<Integer> results = new ArrayList<>(dice);
 
         for (int i = 0; i < dice; i++) {
             results.add(rollDice(1, sides));
@@ -89,7 +89,7 @@ public class Dice {
      */
     public int bestOf(int n, int dice, String group) {
         int rolls = Math.min(n, dice);
-        ArrayList<Integer> results = new ArrayList<>(dice);
+        List<Integer> results = new ArrayList<>(dice);
 
         for (int i = 0; i < rolls; i++) {
             results.add(rollGroup(group));

--- a/squidlib-util/src/main/java/squidpony/squidmath/PoissonDisk.java
+++ b/squidlib-util/src/main/java/squidpony/squidmath/PoissonDisk.java
@@ -6,6 +6,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
+import java.util.Set;
 
 /**
  * This provides a Uniform Poisson Disk Sampling technique that can be used to generate random points that have a
@@ -307,7 +308,7 @@ public class PoissonDisk {
      * @param blocked a Set of Characters that block a tile from being chosen
      * @return a Coord that corresponds to a map element equal to tile, or null if tile cannot be found or if map is too small.
      */
-    public static Coord randomUnblockedTile(Coord minPosition, Coord maxPosition, char[][] map, RNG rng, HashSet<Character> blocked)
+    public static Coord randomUnblockedTile(Coord minPosition, Coord maxPosition, char[][] map, RNG rng, Set<Character> blocked)
     {
         int width = map.length;
         int height = map[0].length;

--- a/squidlib-util/src/main/java/squidpony/squidmath/RegionMap.java
+++ b/squidlib-util/src/main/java/squidpony/squidmath/RegionMap.java
@@ -345,7 +345,7 @@ public class RegionMap<V> implements Iterable<RegionMap.Entry<V>> {
     public ArrayList<V> allAt(int x, int y)
     {
         ArrayList<V> found = new ArrayList<>(capacity);
-        ArrayList<short[]> regions = CoordPacker.findManyPacked(x, y, keyTable);
+        Iterable<short[]> regions = CoordPacker.findManyPacked(x, y, keyTable);
         for(short[] region : regions)
         {
             found.add(get(region));

--- a/squidlib-util/src/test/java/squidpony/examples/DijkstraCostTest.java
+++ b/squidlib-util/src/test/java/squidpony/examples/DijkstraCostTest.java
@@ -11,6 +11,7 @@ import squidpony.squidmath.LightRNG;
 import squidpony.squidmath.RNG;
 
 import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Created by Tommy Ettinger on 9/8/2015.
@@ -25,7 +26,7 @@ public class DijkstraCostTest {
             dg.addDoors(8, true);
 
             char[][] dun = dg.generate(TilesetType.DEFAULT_DUNGEON);
-            HashMap<Character, Double> aquatic = new HashMap<>(16);
+            Map<Character, Double> aquatic = new HashMap<>(16);
             aquatic.put('~', 1.0);
             aquatic.put(',', 1.0);
             double[][] costs = DungeonUtility.generateCostMap(dun, aquatic, 999.0);
@@ -79,7 +80,7 @@ public class DijkstraCostTest {
             dg.addDoors(16, true);
 
             dun = dg.generate(TilesetType.DEFAULT_DUNGEON);
-            HashMap<Character, Double> vampire = new HashMap<>(16);
+            Map<Character, Double> vampire = new HashMap<>(16);
             vampire.put('/', 999.0);
             vampire.put('+', 999.0);
             vampire.put('~', 3.0);
@@ -142,7 +143,7 @@ public class DijkstraCostTest {
             dg.addDoors(10, true);
 
             dun = DungeonUtility.closeDoors(dg.generate(TilesetType.DEFAULT_DUNGEON));
-            HashMap<Character, Double> fancy = new HashMap<>(16);
+            Map<Character, Double> fancy = new HashMap<>(16);
             fancy.put(',', 2.0);
             fancy.put('~', 8.0);
             fancy.put('+', 4.0);

--- a/squidlib-util/src/test/java/squidpony/examples/LOSComparisonTest.java
+++ b/squidlib-util/src/test/java/squidpony/examples/LOSComparisonTest.java
@@ -10,6 +10,7 @@ import squidpony.squidmath.LightRNG;
 import squidpony.squidmath.StatefulRNG;
 
 import java.util.ArrayList;
+import java.util.List;
 
 /**
  * A quick test to visually compare the results of five different LOS algorithms.
@@ -32,7 +33,7 @@ public class LOSComparisonTest {
             short[] flooded = CoordPacker.flood(floors, CoordPacker.packOne(start), 10, true);
             short[] outside = CoordPacker.differencePacked(CoordPacker.rectangle(width, height),// flooded);
                     CoordPacker.expand(flooded, 1, width, height));
-            ArrayList<Coord> allSeen = new ArrayList<>(23 * 23), targets = new ArrayList<>(5);
+            List<Coord> allSeen = new ArrayList<>(23 * 23), targets = new ArrayList<>(5);
             LOS los;
             if(l < 7) los = new LOS(l);
             else los = new LOS(6);

--- a/squidlib-util/src/test/java/squidpony/examples/PoissonDiskTest.java
+++ b/squidlib-util/src/test/java/squidpony/examples/PoissonDiskTest.java
@@ -26,7 +26,7 @@ public class PoissonDiskTest {
 
         // System.out.println(dg);
 
-        ArrayList<Coord> disks = PoissonDisk.sampleMap(dun, 7f, rng, '#');
+        Iterable<Coord> disks = PoissonDisk.sampleMap(dun, 7f, rng, '#');
 
         //char[][] hl = DungeonUtility.hashesToLines(dun);
         for(Coord c : disks)

--- a/squidlib-util/src/test/java/squidpony/examples/SoundTest.java
+++ b/squidlib-util/src/test/java/squidpony/examples/SoundTest.java
@@ -10,6 +10,7 @@ import squidpony.squidmath.RNG;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Created by Tommy Ettinger on 4/25/2015.
@@ -25,14 +26,14 @@ public class SoundTest {
 
             System.out.println(dg);
 
-            HashSet<Coord> dudes = new HashSet<>(5);
+            Set<Coord> dudes = new HashSet<>(5);
             dudes.add(dg.utility.randomFloor(dun));
             dudes.add(dg.utility.randomFloor(dun));
             dudes.add(dg.utility.randomFloor(dun));
             dudes.add(dg.utility.randomFloor(dun));
             dudes.add(dg.utility.randomFloor(dun));
 
-            HashMap<Coord, Double> noises = new HashMap<>(8);
+            Map<Coord, Double> noises = new HashMap<>(8);
             for(int i = 0; i < 6; i++)
             {
                 noises.put(dg.utility.randomStep(dun, dg.utility.randomFloor(dun),

--- a/squidlib-util/src/test/java/squidpony/examples/SpillTest.java
+++ b/squidlib-util/src/test/java/squidpony/examples/SpillTest.java
@@ -13,6 +13,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Set;
 
 /**
  * A test for the randomized flood-fill in the Spill class. This runs the Spill twice from the same starting position,
@@ -33,12 +35,12 @@ public class SpillTest {
             System.out.println(dg);
 
             Coord entry = dg.utility.randomFloor(dun);
-            HashSet<Coord> impassable = new HashSet<>();
+            Set<Coord> impassable = new HashSet<>();
             impassable.add(Coord.get(entry.x + 2, entry.y));
             impassable.add(Coord.get(entry.x - 2, entry.y));
             impassable.add(Coord.get(entry.x, entry.y + 2));
             impassable.add(Coord.get(entry.x, entry.y - 2));
-            ArrayList<Coord> ordered = spreader.start(entry, 20, impassable);
+            List<Coord> ordered = spreader.start(entry, 20, impassable);
             ordered.addAll(spreader.start(entry, 35, impassable));
             boolean[][] sm = spreader.spillMap;
             char[][] md = Arrays.copyOf(dun, dun.length),
@@ -70,7 +72,7 @@ public class SpillTest {
             short[] valid = CoordPacker.pack(dun, '.');
 
             LinkedHashMap<Coord, Double> entries = new LinkedHashMap<>(16);
-            ArrayList<Coord> section = CoordPacker.randomPortion(valid, 16, rng);
+            List<Coord> section = CoordPacker.randomPortion(valid, 16, rng);
             for (int i = 0; i < 4; i++) {
                 entries.put(section.get(i * 4    ), 1.0);
                 entries.put(section.get(i * 4 + 1), 0.75);

--- a/squidlib-util/src/test/java/squidpony/performance/WaypointPerformanceTest.java
+++ b/squidlib-util/src/test/java/squidpony/performance/WaypointPerformanceTest.java
@@ -9,6 +9,7 @@ import squidpony.squidmath.LightRNG;
 import squidpony.squidmath.StatefulRNG;
 
 import java.util.ArrayList;
+import java.util.List;
 
 /**
  * a simple performance test
@@ -66,7 +67,7 @@ final class WaypointPerformanceTest extends AbstractPerformanceTest {
 		@Override
 		protected void doWork() {
 			Coord r, s;
-            ArrayList<Coord> path;
+            List<Coord> path;
 			pathfinder = new WaypointPathfinder(map, Radius.DIAMOND, new StatefulRNG(new LightRNG(0x1337BEEF)));
 			for (int x = 1; x < WIDTH - 1; x++) {
 				for (int y = 1; y < HEIGHT - 1; y++) {

--- a/squidlib-util/src/test/java/squidpony/squidmath/CoordPackerTest.java
+++ b/squidlib-util/src/test/java/squidpony/squidmath/CoordPackerTest.java
@@ -13,6 +13,7 @@ import squidpony.squidgrid.mapping.styled.TilesetType;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.Set;
 
 import static org.junit.Assert.*;
 import static squidpony.squidmath.CoordPacker.*;
@@ -353,7 +354,7 @@ public class CoordPackerTest {
         System.out.println();
         printPacked(doors, 60, 60);
         System.out.println();
-        ArrayList<short[]> separatedCorridors = split(corridors), separatedRooms = split(rooms);
+        Iterable<short[]> separatedCorridors = split(corridors), separatedRooms = split(rooms);
         for (short[] sep : separatedRooms) {
             printPacked(sep, 60, 60);
             System.out.println();
@@ -532,7 +533,7 @@ public class CoordPackerTest {
             short[][] packed;
             int ramPacked = 0, ramFloat = 0, ramDouble = 0;
             Coord viewer;
-            HashSet<Double> seenValues = new HashSet<>(FOV_RANGE * 2);
+            Set<Double> seenValues = new HashSet<>(FOV_RANGE * 2);
             /*
             System.out.println("Packing levels at range " + FOV_RANGE + ": ");
             for (Double d : packingLevels) {
@@ -664,7 +665,7 @@ public class CoordPackerTest {
             short[][] packed;
             int ramPacked = 0, ramFloat = 0, ramDouble = 0;
             Coord viewer;
-            HashSet<Double> seenValues = new HashSet<>(FOV_RANGE * 2);
+            Set<Double> seenValues = new HashSet<>(FOV_RANGE * 2);
             /*
             System.out.println("Packing levels at range " + FOV_RANGE + ": ");
             for (Double d : packingLevels) {

--- a/squidlib/src/main/java/squidpony/squidgrid/gui/gdx/SColorFactory.java
+++ b/squidlib/src/main/java/squidpony/squidgrid/gui/gdx/SColorFactory.java
@@ -19,8 +19,8 @@ import java.util.*;
  */
 public class SColorFactory {
 
-    private final TreeMap<String, SColor> nameLookup;
-    private final TreeMap<Integer, SColor> valueLookup;
+    private final Map<String, SColor> nameLookup;
+    private final Map<Integer, SColor> valueLookup;
     private RNG rng;
     private Map<Integer, SColor> colorBag;
     private Map<String, ArrayList<SColor>> palettes;
@@ -483,7 +483,7 @@ public class SColorFactory {
      * @return
      */
     public SColor fromPalette(String name, float percent) {
-        ArrayList<SColor> list = palettes.get(name);
+        List<SColor> list = palettes.get(name);
         if (list == null) {
             return null;
         }
@@ -508,7 +508,7 @@ public class SColorFactory {
      * @deprecated Prefer fromPalette over this misspelled version; they are equivalent.
      */
     public SColor fromPallet(String name, float percent) {
-        ArrayList<SColor> list = palettes.get(name);
+        List<SColor> list = palettes.get(name);
         if (list == null) {
             return null;
         }
@@ -537,7 +537,7 @@ public class SColorFactory {
      * @param name
      * @param palette
      */
-    public void addPalette(String name, ArrayList<SColor> palette) {
+    public void addPalette(String name, Iterable<SColor> palette) {
         ArrayList<SColor> temp = new ArrayList<>();
 
         //make sure all the colors in the palette are also in the general color cache

--- a/squidlib/src/main/java/squidpony/squidgrid/gui/gdx/SquidLayers.java
+++ b/squidlib/src/main/java/squidpony/squidgrid/gui/gdx/SquidLayers.java
@@ -11,6 +11,7 @@ import squidpony.squidgrid.Direction;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashSet;
+import java.util.List;
 
 /**
  * A helper class to make using multiple HDRPanels easier.
@@ -25,7 +26,7 @@ public class SquidLayers extends Group {
     protected int cellHeight;
     protected SquidPanel backgroundPanel, foregroundPanel;
     protected int[][] lightnesses;
-    protected ArrayList<SquidPanel> extraPanels;
+    protected List<SquidPanel> extraPanels;
     protected TextCellFactory textFactory;
     protected ArrayList<Color> palette;
     protected boolean[][] values;
@@ -636,7 +637,7 @@ public class SquidLayers extends Group {
      * @param bgPalette           an alternate Color ArrayList for the background; can be null to use the default.
      * @param backgroundLightness int between -255 and 255 , lower numbers are darker, higher lighter.
      */
-    public SquidLayers put(int x, int y, char c, int foregroundIndex, ArrayList<Color> fgPalette, int backgroundIndex, ArrayList<Color> bgPalette, int backgroundLightness) {
+    public SquidLayers put(int x, int y, char c, int foregroundIndex, ArrayList<Color> fgPalette, int backgroundIndex, List<Color> bgPalette, int backgroundLightness) {
         if (fgPalette == null) fgPalette = palette;
         if (bgPalette == null) bgPalette = palette;
         foregroundPanel.put(x, y, c, foregroundIndex, fgPalette);
@@ -770,7 +771,7 @@ public class SquidLayers extends Group {
      * @param bgPalette           an alternate Color ArrayList for the background; can be null to use the default.
      * @param backgroundLightness int[][] with elements between -255 and 255 , lower darker, higher lighter.
      */
-    public SquidLayers put(int x, int y, char[][] c, int[][] foregroundIndex, ArrayList<Color> fgPalette, int[][] backgroundIndex, ArrayList<Color> bgPalette, int[][] backgroundLightness) {
+    public SquidLayers put(int x, int y, char[][] c, int[][] foregroundIndex, ArrayList<Color> fgPalette, int[][] backgroundIndex, List<Color> bgPalette, int[][] backgroundLightness) {
         if (fgPalette == null) fgPalette = palette;
         if (bgPalette == null) bgPalette = palette;
         foregroundPanel.put(x, y, c, foregroundIndex, fgPalette);
@@ -1051,7 +1052,7 @@ public class SquidLayers extends Group {
      * @param backgroundIndex the indexed color to use
      * @return this, for chaining
      */
-    public SquidLayers putString(int x, int y, String s, ArrayList<Color> alternatePalette, int foregroundIndex, int backgroundIndex) {
+    public SquidLayers putString(int x, int y, String s, List<Color> alternatePalette, int foregroundIndex, int backgroundIndex) {
         foregroundPanel.put(x, y, s, alternatePalette.get(foregroundIndex));
         for (int i = x; i < s.length() && i < width; i++) {
             backgroundPanel.put(i, y, alternatePalette.get(backgroundIndex));
@@ -1393,10 +1394,10 @@ public class SquidLayers extends Group {
         return foregroundPanel.animateActor(x, y, doubleWidth, c, color);
     }
 
-    public AnimatedEntity animateActor(int x, int y, char c, int index, ArrayList<Color> palette, int layer) {
+    public AnimatedEntity animateActor(int x, int y, char c, int index, List<Color> palette, int layer) {
         return animateActor(x, y, c, palette.get(index), layer);
     }
-    public AnimatedEntity animateActor(int x, int y, char c, int index, ArrayList<Color> palette) {
+    public AnimatedEntity animateActor(int x, int y, char c, int index, List<Color> palette) {
         return animateActor(x, y, c, palette.get(index));
     }
 
@@ -1478,10 +1479,10 @@ public class SquidLayers extends Group {
         return foregroundPanel.animateActor(x, y, doubleWidth, s, color);
     }
 
-    public AnimatedEntity animateActor(int x, int y, String s, int index, ArrayList<Color> palette, int layer) {
+    public AnimatedEntity animateActor(int x, int y, String s, int index, List<Color> palette, int layer) {
         return animateActor(x, y, s, palette.get(index), layer);
     }
-    public AnimatedEntity animateActor(int x, int y, String s, int index, ArrayList<Color> palette) {
+    public AnimatedEntity animateActor(int x, int y, String s, int index, List<Color> palette) {
         return animateActor(x, y, s, palette.get(index));
     }
 
@@ -1505,16 +1506,16 @@ public class SquidLayers extends Group {
         return foregroundPanel.animateActor(x, y, doubleWidth, stretch, tr, color);
     }
 
-    public AnimatedEntity animateActor(int x, int y, TextureRegion tr, int index, ArrayList<Color> palette, int layer) {
+    public AnimatedEntity animateActor(int x, int y, TextureRegion tr, int index, List<Color> palette, int layer) {
         return animateActor(x, y, tr, palette.get(index), layer);
     }
-    public AnimatedEntity animateActor(int x, int y, TextureRegion tr, int index, ArrayList<Color> palette, int layer, boolean doubleWidth) {
+    public AnimatedEntity animateActor(int x, int y, TextureRegion tr, int index, List<Color> palette, int layer, boolean doubleWidth) {
         return animateActor(x, y, tr, palette.get(index), layer, doubleWidth, true);
     }
-    public AnimatedEntity animateActor(int x, int y, TextureRegion tr, int index, ArrayList<Color> palette, int layer, boolean doubleWidth, boolean stretch) {
+    public AnimatedEntity animateActor(int x, int y, TextureRegion tr, int index, List<Color> palette, int layer, boolean doubleWidth, boolean stretch) {
         return animateActor(x, y, tr, palette.get(index), layer, doubleWidth, stretch);
     }
-    public AnimatedEntity animateActor(int x, int y, TextureRegion tr, int index, ArrayList<Color> palette) {
+    public AnimatedEntity animateActor(int x, int y, TextureRegion tr, int index, List<Color> palette) {
         return animateActor(x, y, tr, palette.get(index));
     }
     public AnimatedEntity animateActor(int x, int y, TextureRegion tr, int index, int layer) {
@@ -1539,7 +1540,7 @@ public class SquidLayers extends Group {
         return animateActor(x, y, tr, Color.WHITE, doubleWidth, stretch);
     }
 
-    public LinkedHashSet<AnimatedEntity> getAnimatedEntities(int layer) {
+    public Iterable<AnimatedEntity> getAnimatedEntities(int layer) {
         SquidPanel p = foregroundPanel;
         switch (layer) {
             case 0:

--- a/squidlib/src/main/java/squidpony/squidgrid/gui/gdx/SquidMessageBox.java
+++ b/squidlib/src/main/java/squidpony/squidgrid/gui/gdx/SquidMessageBox.java
@@ -21,7 +21,7 @@ import java.util.List;
  * Created by Tommy Ettinger on 12/10/2015.
  */
 public class SquidMessageBox extends SquidPanel {
-    protected ArrayList<IColoredString<Color>> messages = new ArrayList<>(256);
+    protected List<IColoredString<Color>> messages = new ArrayList<>(256);
     protected ArrayList<Label> labels = new ArrayList<>(256);
     protected int messageIndex = 0;
     //private static Pattern lineWrapper;

--- a/squidlib/src/main/java/squidpony/squidgrid/gui/gdx/SquidPanel.java
+++ b/squidlib/src/main/java/squidpony/squidgrid/gui/gdx/SquidPanel.java
@@ -19,6 +19,7 @@ import squidpony.squidmath.StatefulRNG;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedHashSet;
+import java.util.List;
 
 /**
  * Displays text and images in a grid pattern. Supports basic animations.
@@ -168,7 +169,7 @@ public class SquidPanel extends Group implements ISquidPanel<Color> {
         }
     }
 
-    public void put(int xOffset, int yOffset, char[][] chars, int[][] indices, ArrayList<Color> palette) {
+    public void put(int xOffset, int yOffset, char[][] chars, int[][] indices, List<Color> palette) {
         for (int x = xOffset; x < xOffset + chars.length; x++) {
             for (int y = yOffset; y < yOffset + chars[0].length; y++) {
                 if (x >= 0 && y >= 0 && x < gridWidth && y < gridHeight) {//check for valid input
@@ -188,7 +189,7 @@ public class SquidPanel extends Group implements ISquidPanel<Color> {
         }
     }
 
-    public void put(int xOffset, int yOffset, int[][] indices, ArrayList<Color> palette) {
+    public void put(int xOffset, int yOffset, int[][] indices, List<Color> palette) {
         for (int x = xOffset; x < xOffset + indices.length; x++) {
             for (int y = yOffset; y < yOffset + indices[0].length; y++) {
                 if (x >= 0 && y >= 0 && x < gridWidth && y < gridHeight) {//check for valid input
@@ -357,11 +358,11 @@ public class SquidPanel extends Group implements ISquidPanel<Color> {
         put(x, y, String.valueOf(Character.toChars(c)), color);
     }
 
-    public void put(int x, int y, int index, ArrayList<Color> palette) {
+    public void put(int x, int y, int index, List<Color> palette) {
         put(x, y, palette.get(index));
     }
 
-    public void put(int x, int y, char c, int index, ArrayList<Color> palette) {
+    public void put(int x, int y, char c, int index, List<Color> palette) {
         put(x, y, c, palette.get(index));
     }
 
@@ -571,7 +572,7 @@ public class SquidPanel extends Group implements ISquidPanel<Color> {
      * @param palette
      * @return
      */
-    public AnimatedEntity animateActor(int x, int y, char c, int index, ArrayList<Color> palette)
+    public AnimatedEntity animateActor(int x, int y, char c, int index, List<Color> palette)
     {
         return animateActor(x, y, c, palette.get(index));
     }
@@ -585,7 +586,7 @@ public class SquidPanel extends Group implements ISquidPanel<Color> {
      * @param palette
      * @return
      */
-    public AnimatedEntity animateActor(int x, int y, String s, int index, ArrayList<Color> palette)
+    public AnimatedEntity animateActor(int x, int y, String s, int index, List<Color> palette)
     {
         return animateActor(x, y, s, palette.get(index));
     }

--- a/squidlib/src/test/java/squidpony/gdx/examples/BasicDemo.java
+++ b/squidlib/src/test/java/squidpony/gdx/examples/BasicDemo.java
@@ -23,6 +23,7 @@ import squidpony.squidmath.RNG;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 
 public class BasicDemo extends ApplicationAdapter {
     SpriteBatch batch;
@@ -46,7 +47,7 @@ public class BasicDemo extends ApplicationAdapter {
     private DijkstraMap playerToCursor;
     private Coord cursor, player;
     private ArrayList<Coord> toCursor;
-    private ArrayList<Coord> awaitedMoves;
+    private List<Coord> awaitedMoves;
     private float secondsWithoutMoves;
     private String[] lang = new String[12];
     private int langIndex = 0;

--- a/squidlib/src/test/java/squidpony/gdx/examples/CoveredPathDemo.java
+++ b/squidlib/src/test/java/squidpony/gdx/examples/CoveredPathDemo.java
@@ -63,7 +63,7 @@ public class CoveredPathDemo extends ApplicationAdapter {
     private DijkstraMap getToRed, getToBlue;
     private Stage stage;
     private int framesWithoutAnimation = 0, moveLength = 6;
-    private ArrayList<Coord> awaitedMoves;
+    private List<Coord> awaitedMoves;
     private int scheduledMoves = 0, whichIdx = 0;
     private boolean blueTurn = false;
     private double frames = 0.0;
@@ -278,15 +278,15 @@ public class CoveredPathDemo extends ApplicationAdapter {
     private void postMove(int idx) {
 
         int i = 0, myMax, myMin;
-        LinkedHashSet<Coord> whichFoes, whichAllies, visibleTargets = new LinkedHashSet<>(8);
+        Set<Coord> whichFoes, whichAllies, visibleTargets = new LinkedHashSet<>(8);
         AnimatedEntity ae = null;
         int health = 0;
         Coord user = null;
         DijkstraMap dijkstra = null;
-        ArrayList<Coord> previous = null;
+        List<Coord> previous = null;
         Color whichTint = Color.WHITE;
-        ArrayList<Creature> whichEnemyTeam;
-        LinkedHashMap<Integer, Threat> myThreats, enemyThreats;
+        List<Creature> whichEnemyTeam;
+        Map<Integer, Threat> myThreats, enemyThreats;
         if (blueTurn) {
             whichFoes = redPlaces;
             whichAllies = bluePlaces;

--- a/squidlib/src/test/java/squidpony/gdx/examples/EverythingDemo.java
+++ b/squidlib/src/test/java/squidpony/gdx/examples/EverythingDemo.java
@@ -29,6 +29,7 @@ import squidpony.squidmath.StatefulRNG;
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 
 public class EverythingDemo extends ApplicationAdapter {
     private enum Phase {WAIT, PLAYER_ANIM, MONSTER_ANIM}
@@ -98,7 +99,7 @@ public class EverythingDemo extends ApplicationAdapter {
     private int framesWithoutAnimation = 0;
     private Coord cursor;
     private ArrayList<Coord> toCursor;
-    private ArrayList<Coord> awaitedMoves;
+    private List<Coord> awaitedMoves;
     private String lang;
     private SquidColorCenter[] colorCenters;
     private int currentCenter;
@@ -234,7 +235,7 @@ public class EverythingDemo extends ApplicationAdapter {
                 initialBGColors = DungeonUtility.generateBGPaletteIndices(decoDungeon);
         colors = new Color[width][height];
         bgColors = new Color[width][height];
-        ArrayList<Color> palette = display.getPalette();
+        List<Color> palette = display.getPalette();
         bgColor = SColor.DARK_SLATE_GRAY;
         for (int i = 0; i < width; i++) {
             for (int j = 0; j < height; j++) {
@@ -437,7 +438,7 @@ public class EverythingDemo extends ApplicationAdapter {
     }
 
     // check if a monster's movement would overlap with another monster.
-    private boolean checkOverlap(Monster mon, int x, int y, ArrayList<Coord> futureOccupied)
+    private boolean checkOverlap(Monster mon, int x, int y, Iterable<Coord> futureOccupied)
     {
         if(monsters.containsPosition(Coord.get(x, y)) && !mon.equals(monsters.get(Coord.get(x, y))))
             return true;
@@ -461,7 +462,7 @@ public class EverythingDemo extends ApplicationAdapter {
         // this is an important piece of DijkstraMap usage; the argument is a Set of Points for squares that
         // temporarily cannot be moved through (not walls, which are automatically known because the map char[][]
         // was passed to the DijkstraMap constructor, but things like moving creatures and objects).
-        LinkedHashSet<Coord> monplaces = monsters.positions();
+        Set<Coord> monplaces = monsters.positions();
 
         pathMap = getToPlayer.scan(monplaces);
 

--- a/squidlib/src/test/java/squidpony/gdx/examples/ImageDemo.java
+++ b/squidlib/src/test/java/squidpony/gdx/examples/ImageDemo.java
@@ -16,6 +16,7 @@ import squidpony.squidmath.LightRNG;
 import squidpony.squidmath.RNG;
 
 import java.util.HashMap;
+import java.util.Map;
 
 public class ImageDemo extends ApplicationAdapter {
     SpriteBatch batch;
@@ -31,7 +32,7 @@ public class ImageDemo extends ApplicationAdapter {
     private SquidInput input;
     private double counter;
     private static final Color bgColor = SColor.DARK_SLATE_GRAY;
-    private HashMap<Coord, AnimatedEntity> creatures;
+    private Map<Coord, AnimatedEntity> creatures;
     private Stage stage;
     @Override
     public void create () {

--- a/squidlib/src/test/java/squidpony/gdx/examples/SquidAIDemo.java
+++ b/squidlib/src/test/java/squidpony/gdx/examples/SquidAIDemo.java
@@ -42,12 +42,12 @@ public class SquidAIDemo extends ApplicationAdapter {
     private SquidInput input;
     private static final Color bgColor = SColor.DARK_SLATE_GRAY;
     private LinkedHashMap<AnimatedEntity, Integer> teamRed, teamBlue;
-    private LinkedHashSet<Coord> redPlaces, bluePlaces;
+    private Set<Coord> redPlaces, bluePlaces;
     private Technique redCone, redCloud, blueBlast, blueBeam;
     private DijkstraMap getToRed, getToBlue;
     private Stage stage;
     private int framesWithoutAnimation = 0, moveLength = 5;
-    private ArrayList<Coord> awaitedMoves;
+    private List<Coord> awaitedMoves;
     private int redIdx = 0, blueIdx = 0;
     private boolean blueTurn = false;
 
@@ -314,7 +314,7 @@ public class SquidAIDemo extends ApplicationAdapter {
         Coord user = null;
         Color whichTint = Color.WHITE;
         LinkedHashMap<AnimatedEntity, Integer> whichEnemyTeam = null;
-        LinkedHashMap<Coord, Double> effects = null;
+        Map<Coord, Double> effects = null;
         if (blueTurn) {
             whichTech = (idx % 2 == 0) ? blueBeam : blueBlast;
             whichFoes = redPlaces;
@@ -356,7 +356,7 @@ public class SquidAIDemo extends ApplicationAdapter {
                 visibleTargets.add(p);
             }
         }
-        LinkedHashMap<Coord, ArrayList<Coord>> ideal = whichTech.idealLocations(user, visibleTargets, whichAllies);
+        Map<Coord, ArrayList<Coord>> ideal = whichTech.idealLocations(user, visibleTargets, whichAllies);
         Coord targetCell = null;
         for(Coord ip : ideal.keySet())
         {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1319 - “ Declarations should use Java collection interfaces such as "List" rather than specific implementation classes such as "LinkedList" ”. You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1319
Please let me know if you have any questions.
Ayman Abdelghany.