### PR TITLE
Change ICombined#fill's first parameter to an enum + add ICombinedPan…

### DIFF
--- a/squidlib-util/src/main/java/squidpony/panel/ICombinedPanel.java
+++ b/squidlib-util/src/main/java/squidpony/panel/ICombinedPanel.java
@@ -1,5 +1,6 @@
 package squidpony.panel;
 
+import squidpony.IColorCenter;
 import squidpony.annotation.Beta;
 
 /**
@@ -110,12 +111,57 @@ public interface ICombinedPanel<T> {
 
 	/**
 	 * @param what
-	 *            {@code true} to fill the foreground, {@code false} to fill the
-	 *            background. {@code null} to fill both.
+	 * 			  What to fill
 	 * @param color
 	 *            The color to put within this panel.
 	 */
-	void fill(Boolean what, T color);
+	void fill(What what, T color);
+
+	/**
+	 * Changes the underlying {@link IColorCenter}.
+	 * 
+	 * @param icc
+	 */
+	public void setColorCenter(IColorCenter<T> icc);
+
+	/**
+	 * What to fill
+	 * 
+	 * @author smelC
+	 */
+	public static enum What {
+		BG,
+		FG,
+		BG_AND_FG;
+
+		/**
+		 * @return {@code true} if {@code this} contains the background.
+		 */
+		public boolean hasBG() {
+			switch (this) {
+			case BG:
+			case BG_AND_FG:
+				return true;
+			case FG:
+				return false;
+			}
+			throw new IllegalStateException("Unmatched value: " + this);
+		}
+
+		/**
+		 * @return {@code true} if {@code this} contains the foreground.
+		 */
+		public boolean hasFG() {
+			switch (this) {
+			case FG:
+			case BG_AND_FG:
+				return true;
+			case BG:
+				return false;
+			}
+			throw new IllegalStateException("Unmatched value: " + this);
+		}
+	}
 
 	/**
 	 * A generic implementation of {@link ICombinedPanel}. Useful to combine
@@ -216,17 +262,24 @@ public interface ICombinedPanel<T> {
 		}
 
 		@Override
-		public void fill(Boolean what, T color) {
+		public void fill(What what, T color) {
+			/* Nope, not Doom's Big Fucking Gun */
+			final boolean bfg = what.hasFG();
+			final boolean bbg = what.hasBG();
 			for (int x = 0; x < width; x++) {
 				for (int y = 0; y < height; y++) {
-					final boolean fg = what == null || what;
-					final boolean bg = what == null || !what;
-					if (fg)
+					if (bfg)
 						putFG(x, y, ' ', color);
-					if (bg)
+					if (bbg)
 						putBG(x, y, color);
 				}
 			}
+		}
+
+		@Override
+		public void setColorCenter(IColorCenter<T> icc) {
+			bg.setColorCenter(icc);
+			fg.setColorCenter(icc);
 		}
 
 	}

--- a/squidlib-util/src/main/java/squidpony/panel/ISquidPanel.java
+++ b/squidlib-util/src/main/java/squidpony/panel/ISquidPanel.java
@@ -1,5 +1,6 @@
 package squidpony.panel;
 
+import squidpony.IColorCenter;
 import squidpony.annotation.Beta;
 
 /**
@@ -127,6 +128,14 @@ public interface ISquidPanel<T> {
 	 *         {@code null}.
 	 */
 	T getDefaultForegroundColor();
+
+	/**
+	 * Method to change the backing {@link IColorCenter}.
+	 * 
+	 * @param icc
+	 * @return {@code this}
+	 */
+	public ISquidPanel<T> setColorCenter(IColorCenter<T> icc);
 
 	/**
 	 * @return The panel doing the real job, i.e. an instance of

--- a/squidlib-util/src/main/java/squidpony/squidgrid/FOVCache.java
+++ b/squidlib-util/src/main/java/squidpony/squidgrid/FOVCache.java
@@ -463,7 +463,8 @@ public class FOVCache extends FOV{
      * @param viewerY an int less than 256 and less than height
      * @return a multi-packed series of progressively wider FOV radii
      */
-    private short[][] calculatePackedExternalFOV(int viewerX, int viewerY)
+    @SuppressWarnings("unused")
+	private short[][] calculatePackedExternalFOV(int viewerX, int viewerY)
     {
         if(viewerX < 0 || viewerY < 0 || viewerX >= width || viewerY >= height)
             return ALL_WALLS;
@@ -597,7 +598,8 @@ public class FOVCache extends FOV{
     {
         return (((bytesPerItem * length + 12 - 1) / 8) + 1) * 8L;
     }
-    private long arrayMemoryUsage2D(int xSize, int ySize, long bytesPerItem)
+    @SuppressWarnings("unused")
+	private long arrayMemoryUsage2D(int xSize, int ySize, long bytesPerItem)
     {
         return arrayMemoryUsage(xSize, (((bytesPerItem * ySize + 12 - 1) / 8) + 1) * 8L);
     }
@@ -1232,7 +1234,8 @@ public class FOVCache extends FOV{
      * something has gone wrong.
      * @return true if cacheAllPerformance() has successfully completed, false otherwise.
      */
-    private boolean awaitCachePerformance()
+    @SuppressWarnings("unused")
+	private boolean awaitCachePerformance()
     {
         if(performanceThread == null && !complete)
             cacheAllPerformance();
@@ -1317,7 +1320,8 @@ public class FOVCache extends FOV{
     }
 
 
-    private byte heuristic(Direction target) {
+    @SuppressWarnings("unused")
+	private byte heuristic(Direction target) {
         switch (radiusKind) {
             case CIRCLE:
             case SPHERE:
@@ -1514,7 +1518,8 @@ public class FOVCache extends FOV{
      * @param radius        the distance the light will extend to
      * @return the computed light grid
      */
-    public double[][] calculateFOV(double[][] resistanceMap, int startx, int starty, double radius) {
+    @Override
+	public double[][] calculateFOV(double[][] resistanceMap, int startx, int starty, double radius) {
         if((qualityComplete || complete) && radius > 0 && radius <= maxRadius)
             return unpackMultiDoublePartial(cache[startx + starty * width], width, height,
                     levels[(int) Math.round(radius)], (int) Math.round(radius));
@@ -1550,7 +1555,8 @@ public class FOVCache extends FOV{
      * @param radiusTechnique provides a means to calculate the radius as desired
      * @return the computed light grid
      */
-    public double[][] calculateFOV(double[][] resistanceMap, int startX, int startY, double radius,
+    @Override
+	public double[][] calculateFOV(double[][] resistanceMap, int startX, int startY, double radius,
                                    Radius radiusTechnique) {
         if((qualityComplete || complete) && radius > 0 && radius <= maxRadius &&
                 radiusKind.equals2D(radiusTechnique))
@@ -1593,7 +1599,8 @@ public class FOVCache extends FOV{
      * @param span            the angle in degrees that measures the full arc contained in the FOV cone
      * @return the computed light grid
      */
-    public double[][] calculateFOV(double[][] resistanceMap, int startX, int startY, double radius,
+    @Override
+	public double[][] calculateFOV(double[][] resistanceMap, int startX, int startY, double radius,
                                    Radius radiusTechnique, double angle, double span) {
         if((qualityComplete || complete) && radius > 0 && radius <= maxRadius &&
                 radiusKind.equals2D(radiusTechnique))
@@ -1627,7 +1634,7 @@ public class FOVCache extends FOV{
             return new Coord[0];
         boolean on = false;
         int idx = 0, xt, yt;
-        short x =0, y = 0, dist = 0;
+        short x =0, y = 0;
         path.add(Coord.get(startX, startY));
         if(startX == endX && startY == endY)
             return path.toArray(new Coord[1]);

--- a/squidlib-util/src/main/java/squidpony/squidmath/RegionMap.java
+++ b/squidlib-util/src/main/java/squidpony/squidmath/RegionMap.java
@@ -603,7 +603,8 @@ public class RegionMap<V> implements Iterable<RegionMap.Entry<V>> {
         return toString(separator, false);
     }
 
-    public String toString () {
+    @Override
+	public String toString () {
         return toString(", ", true);
     }
 
@@ -640,7 +641,8 @@ public class RegionMap<V> implements Iterable<RegionMap.Entry<V>> {
         int highest = Integer.highestOneBit(n);
         return  (highest == Integer.lowestOneBit(n)) ? highest : highest << 1;
     }
-    public Entries<V> iterator () {
+    @Override
+	public Entries<V> iterator () {
         return entries();
     }
 
@@ -705,7 +707,8 @@ public class RegionMap<V> implements Iterable<RegionMap.Entry<V>> {
         public short[] key;
         public V value;
 
-        public String toString () {
+        @Override
+		public String toString () {
             return "Packed Region:" + CoordPacker.encodeASCII(key) + "=" + value;
         }
     }
@@ -739,7 +742,8 @@ public class RegionMap<V> implements Iterable<RegionMap.Entry<V>> {
             }
         }
 
-        public void remove () {
+        @Override
+		public void remove () {
             if (currentIndex < 0) throw new IllegalStateException("next must be called before remove.");
             if (currentIndex >= map.capacity) {
                 map.removeStashIndex(currentIndex);
@@ -762,7 +766,8 @@ public class RegionMap<V> implements Iterable<RegionMap.Entry<V>> {
         }
 
         /** Note the same entry instance is returned each time this method is called. */
-        public Entry<V> next () {
+        @Override
+		public Entry<V> next () {
             if (!hasNext) throw new NoSuchElementException();
             if (!valid) throw new RuntimeException("#iterator() cannot be used nested.");
             short[][] keyTable = map.keyTable;
@@ -773,12 +778,14 @@ public class RegionMap<V> implements Iterable<RegionMap.Entry<V>> {
             return entry;
         }
 
-        public boolean hasNext () {
+        @Override
+		public boolean hasNext () {
             if (!valid) throw new RuntimeException("#iterator() cannot be used nested.");
             return hasNext;
         }
 
-        public Entries<V> iterator () {
+        @Override
+		public Entries<V> iterator () {
             return this;
         }
     }
@@ -788,12 +795,14 @@ public class RegionMap<V> implements Iterable<RegionMap.Entry<V>> {
             super(map);
         }
 
-        public boolean hasNext () {
+        @Override
+		public boolean hasNext () {
             if (!valid) throw new RuntimeException("#iterator() cannot be used nested.");
             return hasNext;
         }
 
-        public V next () {
+        @Override
+		public V next () {
             if (!hasNext) throw new NoSuchElementException();
             if (!valid) throw new RuntimeException("#iterator() cannot be used nested.");
             V value = map.valueTable[nextIndex];
@@ -802,7 +811,8 @@ public class RegionMap<V> implements Iterable<RegionMap.Entry<V>> {
             return value;
         }
 
-        public Values<V> iterator () {
+        @Override
+		public Values<V> iterator () {
             return this;
         }
 
@@ -824,12 +834,14 @@ public class RegionMap<V> implements Iterable<RegionMap.Entry<V>> {
             super((RegionMap<Object>) map);
         }
 
-        public boolean hasNext () {
+        @Override
+		public boolean hasNext () {
             if (!valid) throw new RuntimeException("#iterator() cannot be used nested.");
             return hasNext;
         }
 
-        public short[] next () {
+        @Override
+		public short[] next () {
             if (!hasNext) throw new NoSuchElementException();
             if (!valid) throw new RuntimeException("#iterator() cannot be used nested.");
             short[] key = map.keyTable[nextIndex];
@@ -838,7 +850,8 @@ public class RegionMap<V> implements Iterable<RegionMap.Entry<V>> {
             return key;
         }
 
-        public Keys iterator () {
+        @Override
+		public Keys iterator () {
             return this;
         }
 

--- a/squidlib-util/src/main/java/squidpony/squidmath/ShortSet.java
+++ b/squidlib-util/src/main/java/squidpony/squidmath/ShortSet.java
@@ -430,14 +430,16 @@ public class ShortSet {
         return (h ^ h >>> hashShift) & mask;
     }
 
-    public int hashCode () {
+    @Override
+	public int hashCode () {
         int h = 0;
         for (int i = 0, n = capacity + stashSize; i < n; i++)
             if (keyTable[i] != EMPTY) h += keyTable[i];
         return h;
     }
 
-    public boolean equals (Object obj) {
+    @Override
+	public boolean equals (Object obj) {
         if (!(obj instanceof ShortSet)) return false;
         ShortSet other = (ShortSet)obj;
         if (other.size != size) return false;
@@ -447,7 +449,8 @@ public class ShortSet {
         return true;
     }
 
-    public String toString () {
+    @Override
+	public String toString () {
         if (size == 0) return "[]";
         StringBuilder buffer = new StringBuilder(32);
         buffer.append('[');

--- a/squidlib/src/main/java/squidpony/squidgrid/gui/gdx/ButtonsPanel.java
+++ b/squidlib/src/main/java/squidpony/squidgrid/gui/gdx/ButtonsPanel.java
@@ -22,6 +22,7 @@ import com.badlogic.gdx.scenes.scene2d.actions.Actions;
 
 import squidpony.SquidTags;
 import squidpony.panel.IColoredString;
+import squidpony.panel.ICombinedPanel;
 import squidpony.panel.ISquidPanel;
 import squidpony.squidgrid.gui.gdx.UIUtil.CornerStyle;
 
@@ -456,7 +457,7 @@ public abstract class ButtonsPanel<T extends Color> extends GroupCombinedPanel<T
 			boolean scroll) {
 		if (bgColor != null) {
 			/* Paint whole background */
-			fill(false, bgColor);
+			fill(ICombinedPanel.What.BG, bgColor);
 		}
 
 		if (scroll) {
@@ -464,7 +465,7 @@ public abstract class ButtonsPanel<T extends Color> extends GroupCombinedPanel<T
 			 * Repaint whole foreground, to avoid leaving the end of longest
 			 * entries visible.
 			 */
-			fill(true, bgColor);
+			fill(ICombinedPanel.What.FG, bgColor);
 		}
 
 		final int nbButtons = buttonsTexts.size();
@@ -1136,7 +1137,9 @@ public abstract class ButtonsPanel<T extends Color> extends GroupCombinedPanel<T
 
 	/**
 	 * A convenience subclass for people that give preallocated
-	 * {@link ISquidPanel}s. A single abstract method remains to be implemented.
+	 * {@link ISquidPanel}s. A single abstract method remains to be implemented:
+	 * what to do when a button is pressed, i.e.
+	 * {@link ButtonsPanel#selectedButton(int)}.
 	 * 
 	 * @author smelC
 	 */

--- a/squidlib/src/main/java/squidpony/squidgrid/gui/gdx/Filters.java
+++ b/squidlib/src/main/java/squidpony/squidgrid/gui/gdx/Filters.java
@@ -1,23 +1,29 @@
 package squidpony.squidgrid.gui.gdx;
 
 import com.badlogic.gdx.graphics.Color;
+
+import squidpony.IFilter;
 import squidpony.squidmath.LightRNG;
 
 /**
- * A group of nested classes under the empty interface Filters, these all are meant to perform different changes
+ * Implementations of {@link IFilter}, that all are meant to perform different changes
  * to colors before they are created (they should be passed to SquidColorCenter's constructor, which can use them).
  * Created by Tommy Ettinger on 10/31/2015.
  */
-public interface Filters {
+public class Filters {
+
+	private Filters() {
+		/* You should not build me */
+	}
 
     /**
      * A Filter that does nothing to the colors it is given but pass them along unchanged.
      */
-    class IdentityFilter extends Filter<Color>
+    public static class IdentityFilter implements IFilter<Color>
     {
         public IdentityFilter()
         {
-            state = new float[0];
+        	/* Nothing to do */
         }
 
         @Override
@@ -29,11 +35,11 @@ public interface Filters {
     /**
      * A Filter that converts all colors passed to it to grayscale, like a black and white film.
      */
-    class GrayscaleFilter extends Filter<Color>
+    public static class GrayscaleFilter implements IFilter<Color>
     {
         public GrayscaleFilter()
         {
-            state = new float[0];
+        	/* Nothing to do */
         }
 
         @Override
@@ -47,7 +53,7 @@ public interface Filters {
      * A Filter that tracks the highest brightness for any component it was assigned and stores it in state as the first
      * and only element.
      */
-    class MaxValueFilter extends Filter<Color>
+    public static class MaxValueFilter extends Filter<Color>
     {
         public MaxValueFilter()
         {
@@ -65,7 +71,7 @@ public interface Filters {
     /**
      * A Filter that performs a brightness adjustment to make dark areas lighter and light areas not much less bright.
      */
-    class GammaCorrectFilter extends Filter<Color> {
+    public static class GammaCorrectFilter extends Filter<Color> {
         /**
          * Sets up a GammaCorrectFilter with the desired gamma adjustment.
          *
@@ -88,7 +94,7 @@ public interface Filters {
      * A Filter that is constructed with a color and linear-interpolates any color it is told to alter toward the color
      * it was constructed with.
      */
-    class LerpFilter extends Filter<Color> {
+    public static class LerpFilter extends Filter<Color> {
         /**
          * Sets up a LerpFilter with the desired color to linearly interpolate towards.
          *
@@ -120,7 +126,7 @@ public interface Filters {
      * A Filter that is constructed with a group of colors and linear-interpolates any color it is told to alter toward
      * the color it was constructed with that has the closest hue.
      */
-    class MultiLerpFilter extends Filter<Color> {
+    public static class MultiLerpFilter extends Filter<Color> {
         private SquidColorCenter globalSCC;
         /**
          * Sets up a MultiLerpFilter with the desired colors to linearly interpolate towards; the lengths of each given
@@ -189,7 +195,7 @@ public interface Filters {
      * distinguishable from other colors by value. Useful for sepia effects, which can be created satisfactorily with
      * {@code new Filters.ColorizeFilter(SColor.CLOVE_BROWN, 0.6f, 0.0f)}.
      */
-    class ColorizeFilter extends Filter<Color> {
+    public static class ColorizeFilter extends Filter<Color> {
         private SquidColorCenter globalSCC;
         /**
          * Sets up a ColorizeFilter with the desired color to colorize towards.
@@ -265,7 +271,7 @@ public interface Filters {
      * A short (poorly recorded) video can be seen here http://i.imgur.com/SEw2LXe.gifv ; performance should be smoother
      * during actual gameplay.
      */
-    class HallucinateFilter extends Filter<Color> {
+    public static class HallucinateFilter extends Filter<Color> {
         private SquidColorCenter globalSCC;
         /**
          * Sets up a HallucinateFilter with the timer at 0..
@@ -295,7 +301,7 @@ public interface Filters {
     /**
      * A Filter that multiplies the saturation of any color requested from it by a number given during construction.
      */
-    class SaturationFilter extends Filter<Color> {
+    public static class SaturationFilter extends Filter<Color> {
         private SquidColorCenter globalSCC;
         /**
          * Sets up a SaturationFilter with the desired saturation multiplier. Using a multiplier of 0f, as you would
@@ -326,7 +332,7 @@ public interface Filters {
      * A Filter that is constructed with a palette of colors and randomly increases or decreases the red, green, and
      * blue components of any color it is told to alter. Good for a "glitchy screen" effect.
      */
-    class WiggleFilter extends Filter<Color> {
+    public static class WiggleFilter extends Filter<Color> {
         LightRNG rng;
         public WiggleFilter()
         {
@@ -348,7 +354,7 @@ public interface Filters {
      *
      * Preview using BLUE_GREEN_SERIES foreground, ACHROMATIC_SERIES background: http://i.imgur.com/2HdZpC9.png
      */
-    class PaletteFilter extends Filter<Color> {
+    public static class PaletteFilter extends Filter<Color> {
         /**
          * Sets up a PaletteFilter with the exact colors to use as individual components; the lengths of each given
          * array should be identical.

--- a/squidlib/src/main/java/squidpony/squidgrid/gui/gdx/GroupCombinedPanel.java
+++ b/squidlib/src/main/java/squidpony/squidgrid/gui/gdx/GroupCombinedPanel.java
@@ -3,6 +3,7 @@ package squidpony.squidgrid.gui.gdx;
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.scenes.scene2d.Group;
 
+import squidpony.IColorCenter;
 import squidpony.SquidTags;
 import squidpony.panel.IColoredString;
 import squidpony.panel.ICombinedPanel;
@@ -167,21 +168,38 @@ public class GroupCombinedPanel<T> extends Group implements ICombinedPanel<T> {
 		fg.put(x, bg.gridHeight() - 1, string);
 	}
 
+	/**
+	 * Writes {@code string} at the bottom left. If {@code string} is wider than
+	 * {@code this}, its end will be stripped.
+	 * 
+	 * @param string
+	 */
+	public void putBottomLeft(IColoredString<? extends T> string) {
+		fg.put(0, bg.gridHeight() - 1, string);
+	}
+
 	@Override
-	public void fill(Boolean what, T color) {
+	public void fill(What what, T color) {
 		final int gridWidth = getGridWidth();
 		final int gridHeight = getGridHeight();
 
+		final boolean bfg = what.hasFG();
+		final boolean bbg = what.hasBG();
+
 		for (int x = 0; x < gridWidth; x++) {
 			for (int y = 0; y < gridHeight; y++) {
-				final boolean fg = what == null || what;
-				final boolean bg = what == null || !what;
-				if (fg)
+				if (bfg)
 					putFG(x, y, ' ', color);
-				if (bg)
+				if (bbg)
 					putBG(x, y, color);
 			}
 		}
+	}
+
+	@Override
+	public void setColorCenter(IColorCenter<T> icc) {
+		bg.setColorCenter(icc);
+		fg.setColorCenter(icc);
 	}
 
 	/**

--- a/squidlib/src/main/java/squidpony/squidgrid/gui/gdx/SquidMessageBox.java
+++ b/squidlib/src/main/java/squidpony/squidgrid/gui/gdx/SquidMessageBox.java
@@ -149,7 +149,7 @@ public class SquidMessageBox extends SquidPanel {
             appendMessage(message);
             return;
         }
-        List<IColoredString<Color>> truncated = new IColoredString.Impl<>(message, defaultForeground).wrap(gridWidth - 2);;
+        List<IColoredString<Color>> truncated = new IColoredString.Impl<>(message, defaultForeground).wrap(gridWidth - 2);
         for (IColoredString<Color> t : truncated)
         {
             appendMessage(t.present());
@@ -182,7 +182,7 @@ public class SquidMessageBox extends SquidPanel {
             appendMessage(message);
             return;
         }
-        List<IColoredString<Color>> truncated = message.wrap(gridWidth - 2);;
+        List<IColoredString<Color>> truncated = message.wrap(gridWidth - 2);
         for (IColoredString<Color> t : truncated)
         {
             appendMessage(t);

--- a/squidlib/src/main/java/squidpony/squidgrid/gui/gdx/SquidPanel.java
+++ b/squidlib/src/main/java/squidpony/squidgrid/gui/gdx/SquidPanel.java
@@ -1165,6 +1165,7 @@ public class SquidPanel extends Group implements ISquidPanel<Color> {
 	 * @throws NullPointerException
 	 *             If {@code scc} is {@code null}.
 	 */
+	@Override
 	public SquidPanel setColorCenter(IColorCenter<Color> scc) {
 		if (scc == null)
 			/* Better fail now than later */

--- a/squidlib/src/main/java/squidpony/squidgrid/gui/gdx/TextPanel.java
+++ b/squidlib/src/main/java/squidpony/squidgrid/gui/gdx/TextPanel.java
@@ -9,6 +9,7 @@ import com.badlogic.gdx.graphics.Color;
 import squidpony.SquidTags;
 import squidpony.annotation.Beta;
 import squidpony.panel.IColoredString;
+import squidpony.panel.ICombinedPanel;
 import squidpony.panel.ISquidPanel;
 import squidpony.squidgrid.gui.gdx.UIUtil.CornerStyle;
 
@@ -105,7 +106,7 @@ public abstract class TextPanel<T extends Color> extends GroupCombinedPanel<T> {
 					getClass().getSimpleName() + "::prepare() should be called before put(boolean)");
 
 		if (backgroundColor != null)
-			fill(false, backgroundColor);
+			fill(ICombinedPanel.What.BG, backgroundColor);
 
 		if (putBorders)
 			putBorder();

--- a/squidlib/src/test/java/squidpony/gdx/examples/EverythingDemo.java
+++ b/squidlib/src/test/java/squidpony/gdx/examples/EverythingDemo.java
@@ -1,5 +1,6 @@
 package squidpony.gdx.examples;
 
+import squidpony.panel.ICombinedPanel;
 import com.badlogic.gdx.ApplicationAdapter;
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.InputAdapter;
@@ -598,7 +599,7 @@ public class EverythingDemo extends ApplicationAdapter {
         	gcp.setPosition(((width / 2) - (w / 2)) * cellWidth, (height / 2) * cellHeight);
 
         	/* Fill the background */
-        	gcp.fill(false, bgColor);
+        	gcp.fill(ICombinedPanel.What.BG, bgColor);
 
         	/* Now, to set the text we have to follow SquidPanel's convention */
         	/* First 0: align left, second 0: first line */


### PR DESCRIPTION
…el#setColorCenter + make Filters a class (as it introduces no new method) instead of an interface + make some classes in Filters implement IFilter directly, when they do not need Filter's #state field + bust some 'missing @Override annotation' warnings

The addition of 'setColorCenter' and the change in filters is what allowed me to use the monochromatic filter in Dungeon Mercenary (https://www.youtube.com/watch?v=CQQlie20WYc).