### PR TITLE
Correct bugs in Zone and Rectangle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,9 @@
 apply plugin: 'java'
-apply plugin: 'eclipse'
-// note from smelC: I did not add a plugin for 'idea' as I don't use it. 
-// Please add it if you do.
+// note from smelC: starting with Eclipse Neon, you should not use
+// gradle's Eclipse plugin (grade :eclipse). Instead you should use Eclipse's buildship project (shipped by default with Eclipse):
+// https://projects.eclipse.org/projects/tools.buildship
+// buildship takes care of generating .classpath and .project files according to your build.gradle files
+// (right-click on a project > Gradle > Refresh Gradle Project).
 
 //Support UTF-8 file encoding even on Windows, where it defaults to something terrible.
 [compileJava, compileTestJava]*.options*.encoding = 'UTF-8'
@@ -50,6 +52,7 @@ sourceSets {
 // 'gdxVersion' itself, and yet be able to build SquidLib standalone too.
 def gdxVersion = System.getenv("gdxVersion") ?: "1.9.6" // As in pom.xml
 project.sourceCompatibility = 1.7
+// project.sourceCompatibility = '1.6'  // For android. Commented because not honored (diamonds) :-(
 
 // In this section you declare the dependencies for your production and test code
 dependencies {

--- a/squidlib-util/src/main/java/squidpony/squidgrid/iterator/SquidIterators.java
+++ b/squidlib-util/src/main/java/squidpony/squidgrid/iterator/SquidIterators.java
@@ -338,7 +338,7 @@ public class SquidIterators {
 
 				if (previous.x == xstart + width - 1) {
 					/* Need to go up and left (one column up, go left) */
-					if (previous.y == ystart - (height - 1) || previous.y == 0) {
+					if (previous.y == ystart - (height - 1)) {
 						/* We're done */
 						return null;
 					} else

--- a/squidlib-util/src/main/java/squidpony/squidgrid/mapping/Rectangle.java
+++ b/squidlib-util/src/main/java/squidpony/squidgrid/mapping/Rectangle.java
@@ -152,6 +152,7 @@ public interface Rectangle extends Zone {
 			final Iterator<Coord> it = cells(r);
 			while (it.hasNext())
 				result.add(it.next());
+			assert result.size() == size(r);
 			return result;
 		}
 
@@ -363,7 +364,7 @@ public interface Rectangle extends Zone {
 
 		@Override
 		public String toString() {
-			return "Room at " + bottomLeft + ", width:" + width + ", height:" + height;
+			return "Rectangle at " + bottomLeft + ", width:" + width + ", height:" + height;
 		}
 
 		// Implementation of Zone:
@@ -406,7 +407,9 @@ public interface Rectangle extends Zone {
 
 		@Override
 		public List<Coord> getAll() {
-			return Utils.cellsList(this);
+			final List<Coord> result = Utils.cellsList(this);
+			assert result.size() == size();
+			return result;
 		}
 
 		@Override
@@ -464,9 +467,11 @@ public interface Rectangle extends Zone {
 
 		@Override
 		public Collection<Coord> getExternalBorder() {
-			final List<Coord> result = new ArrayList<Coord>((width + height) * 2);
+			final Rectangle extension = extend();
+			final List<Coord> result = new ArrayList<Coord>(
+					(extension.getWidth() + extension.getHeight()) * 2);
 			for (Direction dir : Direction.CARDINALS)
-				Utils.getBorder(this, dir, result);
+				Utils.getBorder(extension, dir, result);
 			return result;
 		}
 

--- a/squidlib-util/src/main/java/squidpony/squidgrid/zone/Zone.java
+++ b/squidlib-util/src/main/java/squidpony/squidgrid/zone/Zone.java
@@ -309,41 +309,37 @@ public interface Zone extends Serializable, Iterable<Coord> {
 		/* Convenience implementation, feel free to override. */
 		public Zone translate(int x, int y) {
 			final List<Coord> initial = getAll();
-			final List<Coord> shifted = new ArrayList<Coord>(initial);
 			final int sz = initial.size();
+			final List<Coord> shifted = new ArrayList<Coord>(sz);
 			for (int i = 0; i < sz; i++) {
 				final Coord c = initial.get(i);
 				shifted.add(Coord.get(c.x + x, c.y + y));
 			}
+			assert shifted.size() == sz;
 			return new ListZone(shifted);
 		}
 
 		@Override
 		/* Convenience implementation, feel free to override. */
-		public Collection<Coord> getInternalBorder() {
-			final int sz = size();
-			if (sz <= 1)
-				return getAll();
-			final List<Coord> result = new ArrayList<Coord>(sz);
-			final List<Coord> all = getAll();
-			assert sz == all.size();
-			nextCell: for (int i = 0; i < sz; i++) {
-				final Coord c = all.get(i);
-				for (Direction out : Direction.OUTWARDS) {
-					final Coord neighbor = c.translate(out);
-					if (!contains(neighbor)) {
-						result.add(c);
-						continue nextCell;
-					}
-				}
-			}
-			return result;
+		public List<Coord> getInternalBorder() {
+			return size() <= 1 ? getAll() : DungeonUtility.border(getAll(), null);
 		}
 
 		@Override
 		/* Convenience implementation, feel free to override. */
 		public Collection<Coord> getExternalBorder() {
-			return DungeonUtility.border(getAll(), null);
+			final List<Coord> result = new ArrayList<Coord>(size());
+			final List<Coord> internalBorder = getInternalBorder();
+			final int ibsz = internalBorder.size();
+			for (int i = 0; i < ibsz; i++) {
+				final Coord b = internalBorder.get(i);
+				for (Direction dir : Direction.OUTWARDS) {
+					final Coord borderNeighbor = b.translate(dir);
+					if (!contains(borderNeighbor))
+						result.add(borderNeighbor);
+				}
+			}
+			return result;
 		}
 
 		@Override
@@ -358,38 +354,20 @@ public interface Zone extends Serializable, Iterable<Coord> {
 			if (isEmpty())
 				return -1;
 			int min = Integer.MAX_VALUE;
-			if(xOrY)
-			{
-				for (Coord c : this) {
-					if (c.x < min)
-						min = c.x;
-				}
-			}
-			else
-			{
-				for (Coord c : this) {
-					if (c.y < min)
-						min = c.y;
-				}
+			for (Coord c : this) {
+				final int val = xOrY ? c.x : c.y;
+				if (val < min)
+					min = val;
 			}
 			return min;
 		}
 
 		private int biggest(boolean xOrY) {
 			int max = -1;
-			if(xOrY)
-			{
-				for (Coord c : this) {
-					if (c.x > max)
-						max = c.x;
-				}
-			}
-			else
-			{
-				for (Coord c : this) {
-					if (c.y > max)
-						max = c.y;
-				}
+			for (Coord c : this) {
+				final int val = xOrY ? c.x : c.y;
+				if (max < val)
+					max = val;
 			}
 			return max;
 		}


### PR DESCRIPTION
The one in SquidIterators.RectangleFromBottomLeftToTopRight, which was affecting Rectangle::getAll's method (on which a lot methods of Zone's default implementations rely) when coords were on the edge of the dungeon (y == 0) or negative was pretty serious and hard to track.